### PR TITLE
Ignore invalid JSON in responses to requests for it.

### DIFF
--- a/utils.js
+++ b/utils.js
@@ -111,7 +111,10 @@ function httpRequest(url, postData, responseType, callback) {
         if (responseType === 'json') {
           try {
             result = JSON.parse(result);
-          } catch (e) { }
+          } catch (e) {
+            // Don't bother calling the callback if there's no valid JSON.
+            return;
+          }
         }
       }
       callback && callback(type, result);


### PR DESCRIPTION
The real problem that causes #2 is that the server is not returning JSON to a JSON request. Presumably because the server considers it an error.

This PR attempts to fix this by just aborting the ready state change function and not calling the callback. It is assumed that the caller was expecting a parsed JSON data structure and since we are unable to provide that, the callback should be skipped.

To be clear, this simply sidesteps the issue and avoids the stack trace in the console. We still need to investigate why the server is returning such a response and if there is a more appropriate action the extension can take.