### PR TITLE
Fix donate: use click handler to add new tab when donate link is clicked

### DIFF
--- a/options.js
+++ b/options.js
@@ -50,4 +50,9 @@ for (var i = 0; i < inputs.length; i++) {
 // Set the image source
 var img = document.createElement("img");
 img.src = chrome.extension.getURL('assets/images/donate-button.png');
-document.querySelector("#donate-plea a").appendChild(img);
+var donateLink = document.querySelector("#donate-plea a")
+var donateURL = donateLink.href;
+donateLink.appendChild(img);
+donateLink.addEventListener('click', function() {
+  chrome.tabs.create({url: donateURL});
+});


### PR DESCRIPTION
It looks like normal <a> links don't work in Chrome addon button panes. The link is suppressed somehow and doesn't open anywhere.

This CL makes the link functional by "manually" opening a tab when the link is clicked. The `href` property of the original link is used as the tab destination, so someone editing the HTML doesn't have to think too hard about this process.