### PR TITLE
Add unit tests for recap.js

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,9 +1,15 @@
 module.exports = function(grunt) {
   grunt.initConfig({
     jasmine : {
-      src : 'pacer.js',
+      src : [
+        'pacer.js',
+        'recap.js',
+        'utils.js'
+      ],
       options: {
         specs : 'spec/**/*Spec.js',
+        helpers: 'test/mock-ajax.js',
+        polyfills: 'test/Blob.js'
       }
     }
   });

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -1,0 +1,225 @@
+describe('The Recap export module', function() {
+  recap = Recap();
+
+  var docUrls = [
+    'https://ecf.canb.uscourts.gov/doc1/034031424909',
+    'https://ecf.canb.uscourts.gov/doc1/034031425808',
+    'https://ecf.canb.uscourts.gov/doc1/034031438754',
+  ];
+  var court = 'nysd';
+  var docid = '127015406472';
+  var casenum = '437098';
+  var de_seq_num = '70';
+  var dm_id = '14114895';
+  var docnum = '4';
+  var offCaseNum = '12344321';
+  var subdocnum = '0';
+  var filename = 'DktRpt.html';
+  var type = 'text/html';
+  var html = '<html></html>'
+
+
+  beforeEach(function() {
+    jasmine.Ajax.install();
+    jasmine.Ajax.addCustomParamParser({
+      // If the params are a FormData, simply echo them back.
+      test: function(xhr) {
+        return xhr.params instanceof FormData;
+      },
+      parse: function(formData) {
+        return formData;
+      }
+    });
+  });
+
+  afterEach(function() {
+    jasmine.Ajax.uninstall();
+  });
+
+  function setupMetadataResponse(msg) {
+    var caseObj = {};
+    var docObj = {};
+    caseObj[casenum] = {'casenum': casenum, 'officialcasenum': offCaseNum}
+    docObj[docid] = {'casenum': casenum, 'officialcasenum': offCaseNum,
+                     'docnum': docnum, 'subdocnum': subdocnum};
+    return {'documents': docObj, 'cases': caseObj, 'message': msg};
+  }
+
+  function expectMetadata(actCasenum, actOff, actDocnum, actSubdocnum) {
+    expect(actCasenum).toBe(casenum);
+    expect(actOff).toBe(offCaseNum);
+    expect(actDocnum).toBe(docnum);
+    expect(actSubdocnum).toBe(subdocnum);
+  };
+
+  describe('getAvailabilityForDocket', function() {
+    it('requests the correct URL', function() {
+      recap.getAvailabilityForDocket();
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
+        'https://recapextension.org/recap/query_cases/');
+    });
+
+    it('encodes the court and casenum in the POST data', function() {
+      var expectedCourt = 'canb';
+      var expectedCaseNum = '531316';
+      recap.getAvailabilityForDocket(expectedCourt, expectedCaseNum);
+      var actualData = jasmine.Ajax.requests.mostRecent().data();
+      var expectedJson = ('{"court":"'+expectedCourt+'","casenum":"'+
+                          expectedCaseNum+'"}')
+      expect(actualData['json'][0]).toBe(expectedJson);
+    });
+
+    it('calls the callback with the parsed server response', function() {
+      var callback = jasmine.createSpy();
+      var expectedCourt = 'canb';
+      var expectedCaseNum = '531316';
+      recap.getAvailabilityForDocket(expectedCourt, expectedCaseNum, callback);
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        "status": 200,
+        "contentType": 'application/json',
+        "responseText": '{"expectedKey": "expectedValue"}'
+      });
+      expect(callback).toHaveBeenCalledWith({'expectedKey': 'expectedValue'});
+    });
+  });
+
+  describe('getAvailabilityForDocuments', function() {
+    it('requests the correct URL', function() {
+      recap.getAvailabilityForDocuments(docUrls);
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
+        'https://recapextension.org/recap/query/');
+    });
+
+    it('encodes the court and urls in the POST data', function() {
+      recap.getAvailabilityForDocuments(docUrls);
+      var actualData = jasmine.Ajax.requests.mostRecent().data();
+      var expectedJson = ('{"court":"canb","urls":["https://ecf.canb.uscourts' +
+                          '.gov/doc1/034031424909",' +
+                          '"https://ecf.canb.uscourts.gov/doc1/034031425808",' +
+                          '"https://ecf.canb.uscourts.gov/doc1/034031438754"]}')
+      expect(actualData['json'][0]).toBe(expectedJson);
+    });
+
+    it('calls the callback with the parsed server response', function() {
+      var callback = jasmine.createSpy();
+      recap.getAvailabilityForDocuments(docUrls, callback);
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        "status": 200,
+        "contentType": 'application/json',
+        "responseText": '{"expectedKey": "expectedValue"}'
+      });
+      expect(callback).toHaveBeenCalledWith({'expectedKey': 'expectedValue'});
+    });
+  });
+
+  describe('uploadMetadata', function() {
+    it('requests the correct URL', function() {
+      recap.uploadMetadata(court, docid, casenum, de_seq_num, dm_id, docnum);
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
+        'https://recapextension.org/recap/adddocmeta/');
+    });
+
+    // Commented out until we figure out how to compare FormData.
+    xit('sends the correct FormData', function() {
+      var formData = new FormData();
+      formData.append('court', court);
+      formData.append('docid', docid);
+      formData.append('casenum', casenum);
+      formData.append('de_seq_num', de_seq_num);
+      formData.append('dm_id', dm_id);
+      formData.append('docnum', docnum);
+      formData.append('add_case_info', 'true');
+
+      recap.uploadMetadata(court, docid, casenum, de_seq_num, dm_id, docnum);
+      var actualData = jasmine.Ajax.requests.mostRecent().data();
+      expect(actualData).toEqual(formData);
+    });
+
+    it('updates the local metadata', function() {
+      resp = setupMetadataResponse('successfully updated');
+      recap.uploadMetadata(court, docid, casenum, de_seq_num, dm_id, docnum,
+                          function() {});
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        "status": 200,
+        "contentType": 'application/json',
+        "responseText": JSON.stringify(resp)
+      });
+      recap.getDocumentMetadata(docid, expectMetadata);
+    });
+  });
+
+  describe('uploadDocket', function() {
+    it('requests the correct URL', function() {
+      recap.uploadDocket(court, casenum, filename, type, html);
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
+        'https://recapextension.org/recap/upload/');
+    });
+
+    // Commented out until we figure out how to compare FormData.
+    xit('sends the correct FormData', function() {
+      var formData = new FormData();
+      formData.append('court', court);
+      formData.append('mimetype', type);
+      formData.append('data', new Blob([html], {type: type}), filename);
+
+      recap.uploadDocket(court, casenum, filename, type, html);
+      var actualData = jasmine.Ajax.requests.mostRecent().data();
+      expect(actualData).toEqual(formData);
+    });
+
+    it('updates the local metadata', function() {
+      resp = setupMetadataResponse('successfully updated');
+      recap.uploadDocket(court, casenum, filename, type, html, function() {});
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        "status": 200,
+        "contentType": 'application/json',
+        "responseText": JSON.stringify(resp)
+      });
+      recap.getDocumentMetadata(docid, expectMetadata);
+    });
+  });
+
+  describe('uploadAttachmentMenu', function() {
+    it('requests the correct URL', function() {
+      recap.uploadAttachmentMenu(court, filename, type, html);
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
+        'https://recapextension.org/recap/upload/');
+    });
+
+    // Commented out until we figure out how to compare FormData.
+    xit('sends the correct FormData', function() {
+      var formData = new FormData();
+      formData.append('court', court);
+      formData.append('mimetype', type);
+      formData.append('data', new Blob([html], {type: type}), filename);
+
+      recap.uploadAttachmentMenu(court, filename, type, html);
+      var actualData = jasmine.Ajax.requests.mostRecent().data();
+      expect(actualData).toEqual(formData);
+    });
+
+    it('updates the local metadata', function() {
+      resp = setupMetadataResponse('successfully updated');
+      recap.uploadAttachmentMenu(court, filename, type, html, function() {});
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        "status": 200,
+        "contentType": 'application/json',
+        "responseText": JSON.stringify(resp)
+      });
+      recap.getDocumentMetadata(docid, expectMetadata);
+    });
+  });
+
+  describe('uploadDocument', function() {
+    var path = '/doc1/127015406472';
+    var bytes = new Uint8Array([100, 100, 200, 200, 300]);
+
+    it('requests the correct URL', function() {
+      recap.uploadDocument(court, path, filename, type, bytes);
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
+        'https://recapextension.org/recap/upload/');
+    });
+
+    // TODO: test of FormData once we figure out how to do that.
+  });
+});

--- a/test/Blob.js
+++ b/test/Blob.js
@@ -1,0 +1,211 @@
+/* Blob.js
+ * A Blob implementation.
+ * 2014-07-24
+ *
+ * By Eli Grey, http://eligrey.com
+ * By Devin Samarin, https://github.com/dsamarin
+ * License: X11/MIT
+ *   See https://github.com/eligrey/Blob.js/blob/master/LICENSE.md
+ */
+
+/*global self, unescape */
+/*jslint bitwise: true, regexp: true, confusion: true, es5: true, vars: true, white: true,
+  plusplus: true */
+
+/*! @source http://purl.eligrey.com/github/Blob.js/blob/master/Blob.js */
+
+(function (view) {
+	"use strict";
+
+	view.URL = view.URL || view.webkitURL;
+
+	if (view.Blob && view.URL) {
+		try {
+			new Blob;
+			return;
+		} catch (e) {}
+	}
+
+	// Internally we use a BlobBuilder implementation to base Blob off of
+	// in order to support older browsers that only have BlobBuilder
+	var BlobBuilder = view.BlobBuilder || view.WebKitBlobBuilder || view.MozBlobBuilder || (function(view) {
+		var
+			  get_class = function(object) {
+				return Object.prototype.toString.call(object).match(/^\[object\s(.*)\]$/)[1];
+			}
+			, FakeBlobBuilder = function BlobBuilder() {
+				this.data = [];
+			}
+			, FakeBlob = function Blob(data, type, encoding) {
+				this.data = data;
+				this.size = data.length;
+				this.type = type;
+				this.encoding = encoding;
+			}
+			, FBB_proto = FakeBlobBuilder.prototype
+			, FB_proto = FakeBlob.prototype
+			, FileReaderSync = view.FileReaderSync
+			, FileException = function(type) {
+				this.code = this[this.name = type];
+			}
+			, file_ex_codes = (
+				  "NOT_FOUND_ERR SECURITY_ERR ABORT_ERR NOT_READABLE_ERR ENCODING_ERR "
+				+ "NO_MODIFICATION_ALLOWED_ERR INVALID_STATE_ERR SYNTAX_ERR"
+			).split(" ")
+			, file_ex_code = file_ex_codes.length
+			, real_URL = view.URL || view.webkitURL || view
+			, real_create_object_URL = real_URL.createObjectURL
+			, real_revoke_object_URL = real_URL.revokeObjectURL
+			, URL = real_URL
+			, btoa = view.btoa
+			, atob = view.atob
+
+			, ArrayBuffer = view.ArrayBuffer
+			, Uint8Array = view.Uint8Array
+
+			, origin = /^[\w-]+:\/*\[?[\w\.:-]+\]?(?::[0-9]+)?/
+		;
+		FakeBlob.fake = FB_proto.fake = true;
+		while (file_ex_code--) {
+			FileException.prototype[file_ex_codes[file_ex_code]] = file_ex_code + 1;
+		}
+		// Polyfill URL
+		if (!real_URL.createObjectURL) {
+			URL = view.URL = function(uri) {
+				var
+					  uri_info = document.createElementNS("http://www.w3.org/1999/xhtml", "a")
+					, uri_origin
+				;
+				uri_info.href = uri;
+				if (!("origin" in uri_info)) {
+					if (uri_info.protocol.toLowerCase() === "data:") {
+						uri_info.origin = null;
+					} else {
+						uri_origin = uri.match(origin);
+						uri_info.origin = uri_origin && uri_origin[1];
+					}
+				}
+				return uri_info;
+			};
+		}
+		URL.createObjectURL = function(blob) {
+			var
+				  type = blob.type
+				, data_URI_header
+			;
+			if (type === null) {
+				type = "application/octet-stream";
+			}
+			if (blob instanceof FakeBlob) {
+				data_URI_header = "data:" + type;
+				if (blob.encoding === "base64") {
+					return data_URI_header + ";base64," + blob.data;
+				} else if (blob.encoding === "URI") {
+					return data_URI_header + "," + decodeURIComponent(blob.data);
+				} if (btoa) {
+					return data_URI_header + ";base64," + btoa(blob.data);
+				} else {
+					return data_URI_header + "," + encodeURIComponent(blob.data);
+				}
+			} else if (real_create_object_URL) {
+				return real_create_object_URL.call(real_URL, blob);
+			}
+		};
+		URL.revokeObjectURL = function(object_URL) {
+			if (object_URL.substring(0, 5) !== "data:" && real_revoke_object_URL) {
+				real_revoke_object_URL.call(real_URL, object_URL);
+			}
+		};
+		FBB_proto.append = function(data/*, endings*/) {
+			var bb = this.data;
+			// decode data to a binary string
+			if (Uint8Array && (data instanceof ArrayBuffer || data instanceof Uint8Array)) {
+				var
+					  str = ""
+					, buf = new Uint8Array(data)
+					, i = 0
+					, buf_len = buf.length
+				;
+				for (; i < buf_len; i++) {
+					str += String.fromCharCode(buf[i]);
+				}
+				bb.push(str);
+			} else if (get_class(data) === "Blob" || get_class(data) === "File") {
+				if (FileReaderSync) {
+					var fr = new FileReaderSync;
+					bb.push(fr.readAsBinaryString(data));
+				} else {
+					// async FileReader won't work as BlobBuilder is sync
+					throw new FileException("NOT_READABLE_ERR");
+				}
+			} else if (data instanceof FakeBlob) {
+				if (data.encoding === "base64" && atob) {
+					bb.push(atob(data.data));
+				} else if (data.encoding === "URI") {
+					bb.push(decodeURIComponent(data.data));
+				} else if (data.encoding === "raw") {
+					bb.push(data.data);
+				}
+			} else {
+				if (typeof data !== "string") {
+					data += ""; // convert unsupported types to strings
+				}
+				// decode UTF-16 to binary string
+				bb.push(unescape(encodeURIComponent(data)));
+			}
+		};
+		FBB_proto.getBlob = function(type) {
+			if (!arguments.length) {
+				type = null;
+			}
+			return new FakeBlob(this.data.join(""), type, "raw");
+		};
+		FBB_proto.toString = function() {
+			return "[object BlobBuilder]";
+		};
+		FB_proto.slice = function(start, end, type) {
+			var args = arguments.length;
+			if (args < 3) {
+				type = null;
+			}
+			return new FakeBlob(
+				  this.data.slice(start, args > 1 ? end : this.data.length)
+				, type
+				, this.encoding
+			);
+		};
+		FB_proto.toString = function() {
+			return "[object Blob]";
+		};
+		FB_proto.close = function() {
+			this.size = 0;
+			delete this.data;
+		};
+		return FakeBlobBuilder;
+	}(view));
+
+	view.Blob = function(blobParts, options) {
+		var type = options ? (options.type || "") : "";
+		var builder = new BlobBuilder();
+		if (blobParts) {
+			for (var i = 0, len = blobParts.length; i < len; i++) {
+				if (Uint8Array && blobParts[i] instanceof Uint8Array) {
+					builder.append(blobParts[i].buffer);
+				}
+				else {
+					builder.append(blobParts[i]);
+				}
+			}
+		}
+		var blob = builder.getBlob(type);
+		if (!blob.slice && blob.webkitSlice) {
+			blob.slice = blob.webkitSlice;
+		}
+		return blob;
+	};
+
+	var getPrototypeOf = Object.getPrototypeOf || function(object) {
+		return object.__proto__;
+	};
+	view.Blob.prototype = getPrototypeOf(new view.Blob());
+}(typeof self !== "undefined" && self || typeof window !== "undefined" && window || this.content || this));

--- a/test/mock-ajax.js
+++ b/test/mock-ajax.js
@@ -1,0 +1,629 @@
+/*
+
+Jasmine-Ajax - v3.1.0: a set of helpers for testing AJAX requests under the Jasmine
+BDD framework for JavaScript.
+
+http://github.com/jasmine/jasmine-ajax
+
+Jasmine Home page: http://jasmine.github.io/
+
+Copyright (c) 2008-2015 Pivotal Labs
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+*/
+
+getJasmineRequireObj().ajax = function(jRequire) {
+  var $ajax = {};
+
+  $ajax.RequestStub = jRequire.AjaxRequestStub();
+  $ajax.RequestTracker = jRequire.AjaxRequestTracker();
+  $ajax.StubTracker = jRequire.AjaxStubTracker();
+  $ajax.ParamParser = jRequire.AjaxParamParser();
+  $ajax.eventBus = jRequire.AjaxEventBus();
+  $ajax.fakeRequest = jRequire.AjaxFakeRequest($ajax.eventBus);
+  $ajax.MockAjax = jRequire.MockAjax($ajax);
+
+  return $ajax.MockAjax;
+};
+
+getJasmineRequireObj().AjaxEventBus = function() {
+  function EventBus() {
+    this.eventList = {};
+  }
+
+  function ensureEvent(eventList, name) {
+    eventList[name] = eventList[name] || [];
+    return eventList[name];
+  }
+
+  function findIndex(list, thing) {
+    if (list.indexOf) {
+      return list.indexOf(thing);
+    }
+
+    for(var i = 0; i < list.length; i++) {
+      if (thing === list[i]) {
+        return i;
+      }
+    }
+
+    return -1;
+  }
+
+  EventBus.prototype.addEventListener = function(event, callback) {
+    ensureEvent(this.eventList, event).push(callback);
+  };
+
+  EventBus.prototype.removeEventListener = function(event, callback) {
+    var index = findIndex(this.eventList[event], callback);
+
+    if (index >= 0) {
+      this.eventList[event].splice(index, 1);
+    }
+  };
+
+  EventBus.prototype.trigger = function(event) {
+    var eventListeners = this.eventList[event];
+
+    if(eventListeners){
+      for(var i = 0; i < eventListeners.length; i++){
+        eventListeners[i]();
+      }
+    }
+  };
+
+  return function() {
+    return new EventBus();
+  };
+};
+getJasmineRequireObj().AjaxFakeRequest = function(eventBusFactory) {
+  function extend(destination, source, propertiesToSkip) {
+    propertiesToSkip = propertiesToSkip || [];
+    for (var property in source) {
+      if (!arrayContains(propertiesToSkip, property)) {
+        destination[property] = source[property];
+      }
+    }
+    return destination;
+  }
+
+  function arrayContains(arr, item) {
+    for (var i = 0; i < arr.length; i++) {
+      if (arr[i] === item) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  function wrapProgressEvent(xhr, eventName) {
+    return function() {
+      if (xhr[eventName]) {
+        xhr[eventName]();
+      }
+    };
+  }
+
+  function initializeEvents(xhr) {
+    xhr.eventBus.addEventListener('loadstart', wrapProgressEvent(xhr, 'onloadstart'));
+    xhr.eventBus.addEventListener('load', wrapProgressEvent(xhr, 'onload'));
+    xhr.eventBus.addEventListener('loadend', wrapProgressEvent(xhr, 'onloadend'));
+    xhr.eventBus.addEventListener('progress', wrapProgressEvent(xhr, 'onprogress'));
+    xhr.eventBus.addEventListener('error', wrapProgressEvent(xhr, 'onerror'));
+    xhr.eventBus.addEventListener('abort', wrapProgressEvent(xhr, 'onabort'));
+    xhr.eventBus.addEventListener('timeout', wrapProgressEvent(xhr, 'ontimeout'));
+  }
+
+  function unconvertibleResponseTypeMessage(type) {
+    var msg = [
+      "Can't build XHR.response for XHR.responseType of '",
+      type,
+      "'.",
+      "XHR.response must be explicitly stubbed"
+    ];
+    return msg.join(' ');
+  }
+
+  function fakeRequest(global, requestTracker, stubTracker, paramParser) {
+    function FakeXMLHttpRequest() {
+      requestTracker.track(this);
+      this.eventBus = eventBusFactory();
+      initializeEvents(this);
+      this.requestHeaders = {};
+      this.overriddenMimeType = null;
+    }
+
+    function findHeader(name, headers) {
+      name = name.toLowerCase();
+      for (var header in headers) {
+        if (header.toLowerCase() === name) {
+          return headers[header];
+        }
+      }
+    }
+
+    function normalizeHeaders(rawHeaders, contentType) {
+      var headers = [];
+
+      if (rawHeaders) {
+        if (rawHeaders instanceof Array) {
+          headers = rawHeaders;
+        } else {
+          for (var headerName in rawHeaders) {
+            if (rawHeaders.hasOwnProperty(headerName)) {
+              headers.push({ name: headerName, value: rawHeaders[headerName] });
+            }
+          }
+        }
+      } else {
+        headers.push({ name: "Content-Type", value: contentType || "application/json" });
+      }
+
+      return headers;
+    }
+
+    function parseXml(xmlText, contentType) {
+      if (global.DOMParser) {
+        return (new global.DOMParser()).parseFromString(xmlText, 'text/xml');
+      } else {
+        var xml = new global.ActiveXObject("Microsoft.XMLDOM");
+        xml.async = "false";
+        xml.loadXML(xmlText);
+        return xml;
+      }
+    }
+
+    var xmlParsables = ['text/xml', 'application/xml'];
+
+    function getResponseXml(responseText, contentType) {
+      if (arrayContains(xmlParsables, contentType.toLowerCase())) {
+        return parseXml(responseText, contentType);
+      } else if (contentType.match(/\+xml$/)) {
+        return parseXml(responseText, 'text/xml');
+      }
+      return null;
+    }
+
+    var iePropertiesThatCannotBeCopied = ['responseBody', 'responseText', 'responseXML', 'status', 'statusText', 'responseTimeout'];
+    extend(FakeXMLHttpRequest.prototype, new global.XMLHttpRequest(), iePropertiesThatCannotBeCopied);
+    extend(FakeXMLHttpRequest.prototype, {
+      open: function() {
+        this.method = arguments[0];
+        this.url = arguments[1];
+        this.username = arguments[3];
+        this.password = arguments[4];
+        this.readyState = 1;
+        this.onreadystatechange();
+      },
+
+      setRequestHeader: function(header, value) {
+        if(this.requestHeaders.hasOwnProperty(header)) {
+          this.requestHeaders[header] = [this.requestHeaders[header], value].join(', ');
+        } else {
+          this.requestHeaders[header] = value;
+        }
+      },
+
+      overrideMimeType: function(mime) {
+        this.overriddenMimeType = mime;
+      },
+
+      abort: function() {
+        this.readyState = 0;
+        this.status = 0;
+        this.statusText = "abort";
+        this.onreadystatechange();
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('abort');
+        this.eventBus.trigger('loadend');
+      },
+
+      readyState: 0,
+
+      onloadstart: null,
+      onprogress: null,
+      onabort: null,
+      onerror: null,
+      onload: null,
+      ontimeout: null,
+      onloadend: null,
+
+      onreadystatechange: function(isTimeout) {
+      },
+
+      addEventListener: function() {
+        this.eventBus.addEventListener.apply(this.eventBus, arguments);
+      },
+      
+      removeEventListener: function(event, callback) {
+        this.eventBus.removeEventListener.apply(this.eventBus, arguments);
+      },
+
+      status: null,
+
+      send: function(data) {
+        this.params = data;
+        this.readyState = 2;
+        this.eventBus.trigger('loadstart');
+        this.onreadystatechange();
+
+        var stub = stubTracker.findStub(this.url, data, this.method);
+        if (stub) {
+          this.respondWith(stub);
+        }
+      },
+
+      contentType: function() {
+        return findHeader('content-type', this.requestHeaders);
+      },
+
+      data: function() {
+        if (!this.params) {
+          return {};
+        }
+
+        return paramParser.findParser(this).parse(this.params);
+      },
+
+      getResponseHeader: function(name) {
+        name = name.toLowerCase();
+        var resultHeader;
+        for(var i = 0; i < this.responseHeaders.length; i++) {
+          var header = this.responseHeaders[i];
+          if (name === header.name.toLowerCase()) {
+            if (resultHeader) {
+              resultHeader = [resultHeader, header.value].join(', ');
+            } else {
+              resultHeader = header.value;
+            }
+          }
+        }
+        return resultHeader;
+      },
+
+      getAllResponseHeaders: function() {
+        var responseHeaders = [];
+        for (var i = 0; i < this.responseHeaders.length; i++) {
+          responseHeaders.push(this.responseHeaders[i].name + ': ' +
+            this.responseHeaders[i].value);
+        }
+        return responseHeaders.join('\r\n') + '\r\n';
+      },
+
+      responseText: null,
+      response: null,
+      responseType: null,
+
+      responseValue: function() {
+        switch(this.responseType) {
+          case null:
+          case "":
+          case "text":
+            return this.readyState >= 3 ? this.responseText : "";
+          case "json":
+            return JSON.parse(this.responseText);
+          case "arraybuffer":
+            throw unconvertibleResponseTypeMessage('arraybuffer');
+          case "blob":
+            throw unconvertibleResponseTypeMessage('blob');
+          case "document":
+            return this.responseXML;
+        }
+      },
+
+
+      respondWith: function(response) {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.status = response.status;
+        this.statusText = response.statusText || "";
+        this.responseText = response.responseText || "";
+        this.responseType = response.responseType || "";
+        this.readyState = 4;
+        this.responseHeaders = normalizeHeaders(response.responseHeaders, response.contentType);
+        this.responseXML = getResponseXml(response.responseText, this.getResponseHeader('content-type') || '');
+        if (this.responseXML) {
+          this.responseType = 'document';
+        }
+
+        if ('response' in response) {
+          this.response = response.response;
+        } else {
+          this.response = this.responseValue();
+        }
+
+        this.onreadystatechange();
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('load');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseTimeout: function() {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = 4;
+        jasmine.clock().tick(30000);
+        this.onreadystatechange('timeout');
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('timeout');
+        this.eventBus.trigger('loadend');
+      },
+
+      responseError: function() {
+        if (this.readyState === 4) {
+          throw new Error("FakeXMLHttpRequest already completed");
+        }
+        this.readyState = 4;
+        this.onreadystatechange();
+        this.eventBus.trigger('progress');
+        this.eventBus.trigger('error');
+        this.eventBus.trigger('loadend');
+      }
+    });
+
+    return FakeXMLHttpRequest;
+  }
+
+  return fakeRequest;
+};
+
+getJasmineRequireObj().MockAjax = function($ajax) {
+  function MockAjax(global) {
+    var requestTracker = new $ajax.RequestTracker(),
+      stubTracker = new $ajax.StubTracker(),
+      paramParser = new $ajax.ParamParser(),
+      realAjaxFunction = global.XMLHttpRequest,
+      mockAjaxFunction = $ajax.fakeRequest(global, requestTracker, stubTracker, paramParser);
+
+    this.install = function() {
+      if (global.XMLHttpRequest === mockAjaxFunction) {
+        throw "MockAjax is already installed.";
+      }
+
+      global.XMLHttpRequest = mockAjaxFunction;
+    };
+
+    this.uninstall = function() {
+      global.XMLHttpRequest = realAjaxFunction;
+
+      this.stubs.reset();
+      this.requests.reset();
+      paramParser.reset();
+    };
+
+    this.stubRequest = function(url, data, method) {
+      var stub = new $ajax.RequestStub(url, data, method);
+      stubTracker.addStub(stub);
+      return stub;
+    };
+
+    this.withMock = function(closure) {
+      this.install();
+      try {
+        closure();
+      } finally {
+        this.uninstall();
+      }
+    };
+
+    this.addCustomParamParser = function(parser) {
+      paramParser.add(parser);
+    };
+
+    this.requests = requestTracker;
+    this.stubs = stubTracker;
+  }
+
+  return MockAjax;
+};
+
+getJasmineRequireObj().AjaxParamParser = function() {
+  function ParamParser() {
+    var defaults = [
+      {
+        test: function(xhr) {
+          return (/^application\/json/).test(xhr.contentType());
+        },
+        parse: function jsonParser(paramString) {
+          return JSON.parse(paramString);
+        }
+      },
+      {
+        test: function(xhr) {
+          return true;
+        },
+        parse: function naiveParser(paramString) {
+          var data = {};
+          var params = paramString.split('&');
+
+          for (var i = 0; i < params.length; ++i) {
+            var kv = params[i].replace(/\+/g, ' ').split('=');
+            var key = decodeURIComponent(kv[0]);
+            data[key] = data[key] || [];
+            data[key].push(decodeURIComponent(kv[1]));
+          }
+          return data;
+        }
+      }
+    ];
+    var paramParsers = [];
+
+    this.add = function(parser) {
+      paramParsers.unshift(parser);
+    };
+
+    this.findParser = function(xhr) {
+        for(var i in paramParsers) {
+          var parser = paramParsers[i];
+          if (parser.test(xhr)) {
+            return parser;
+          }
+        }
+    };
+
+    this.reset = function() {
+      paramParsers = [];
+      for(var i in defaults) {
+        paramParsers.push(defaults[i]);
+      }
+    };
+
+    this.reset();
+  }
+
+  return ParamParser;
+};
+
+getJasmineRequireObj().AjaxRequestStub = function() {
+  function RequestStub(url, stubData, method) {
+    var normalizeQuery = function(query) {
+      return query ? query.split('&').sort().join('&') : undefined;
+    };
+
+    if (url instanceof RegExp) {
+      this.url = url;
+      this.query = undefined;
+    } else {
+      var split = url.split('?');
+      this.url = split[0];
+      this.query = split.length > 1 ? normalizeQuery(split[1]) : undefined;
+    }
+
+    this.data = normalizeQuery(stubData);
+    this.method = method;
+
+    this.andReturn = function(options) {
+      this.status = options.status || 200;
+
+      this.contentType = options.contentType;
+      this.response = options.response;
+      this.responseText = options.responseText;
+      this.responseHeaders = options.responseHeaders;
+    };
+
+    this.matches = function(fullUrl, data, method) {
+      var matches = false;
+      fullUrl = fullUrl.toString();
+      if (this.url instanceof RegExp) {
+        matches = this.url.test(fullUrl);
+      } else {
+        var urlSplit = fullUrl.split('?'),
+            url = urlSplit[0],
+            query = urlSplit[1];
+        matches = this.url === url && this.query === normalizeQuery(query);
+      }
+      return matches && (!this.data || this.data === normalizeQuery(data)) && (!this.method || this.method === method);
+    };
+  }
+
+  return RequestStub;
+};
+
+getJasmineRequireObj().AjaxRequestTracker = function() {
+  function RequestTracker() {
+    var requests = [];
+
+    this.track = function(request) {
+      requests.push(request);
+    };
+
+    this.first = function() {
+      return requests[0];
+    };
+
+    this.count = function() {
+      return requests.length;
+    };
+
+    this.reset = function() {
+      requests = [];
+    };
+
+    this.mostRecent = function() {
+      return requests[requests.length - 1];
+    };
+
+    this.at = function(index) {
+      return requests[index];
+    };
+
+    this.filter = function(url_to_match) {
+      var matching_requests = [];
+
+      for (var i = 0; i < requests.length; i++) {
+        if (url_to_match instanceof RegExp &&
+            url_to_match.test(requests[i].url)) {
+            matching_requests.push(requests[i]);
+        } else if (url_to_match instanceof Function &&
+            url_to_match(requests[i])) {
+            matching_requests.push(requests[i]);
+        } else {
+          if (requests[i].url === url_to_match) {
+            matching_requests.push(requests[i]);
+          }
+        }
+      }
+
+      return matching_requests;
+    };
+  }
+
+  return RequestTracker;
+};
+
+getJasmineRequireObj().AjaxStubTracker = function() {
+  function StubTracker() {
+    var stubs = [];
+
+    this.addStub = function(stub) {
+      stubs.push(stub);
+    };
+
+    this.reset = function() {
+      stubs = [];
+    };
+
+    this.findStub = function(url, data, method) {
+      for (var i = stubs.length - 1; i >= 0; i--) {
+        var stub = stubs[i];
+        if (stub.matches(url, data, method)) {
+          return stub;
+        }
+      }
+    };
+  }
+
+  return StubTracker;
+};
+
+(function() {
+  var jRequire = getJasmineRequireObj(),
+      MockAjax = jRequire.ajax(jRequire);
+  if (typeof window === "undefined" && typeof exports === "object") {
+    exports.MockAjax = MockAjax;
+    jasmine.Ajax = new MockAjax(exports);
+  } else {
+    window.MockAjax = MockAjax;
+    jasmine.Ajax = new MockAjax(window);
+  }
+}());


### PR DESCRIPTION
Includes test helpers for mocking AJAX in Jasmine and a polyfill for
Blobs in PhantomJS, since the PhantomJS version included by this package
is 1.9 (Blobs are available in 2.0)

See the added tests passing at:
https://travis-ci.org/audiodude/recap-chrome/builds/57119835