### PR TITLE
Refactor content

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -2,9 +2,14 @@ module.exports = function(grunt) {
   grunt.initConfig({
     jasmine : {
       src : [
+        'assets/js/jquery.min.js',
+        'notifier.js',
         'pacer.js',
         'recap.js',
-        'utils.js'
+        'toolbar_button.js',
+        'utils.js',
+        'test/mock-utils.js',
+        'content_delegate.js',
       ],
       options: {
         specs : 'spec/**/*Spec.js',

--- a/content.js
+++ b/content.js
@@ -23,90 +23,26 @@ var recap = importInstance(Recap);
 
 var url = window.location.href;
 var court = PACER.getCourtFromUrl(url);
+var casenum = PACER.getCaseNumberFromUrl(document.referrer);
 
 // Update the toolbar button with knowledge of whether the user is logged in.
 toolbar_button.updateCookieStatus(court, document.cookie, null);
 
+// Create a delegate for handling the various states we might be in.
+var content_delegate = new ContentDelegate(url, court, casenum);
+
 // If this is a docket query page, ask RECAP whether it has the docket page.
-if (PACER.isDocketQueryUrl(url)) {
-  recap.getAvailabilityForDocket(
-    court, PACER.getCaseNumberFromUrl(url), function (result) {
-    if (result && result.docket_url) {
-      // Insert a RECAP download link at the bottom of the form.
-      $('<div class="recap-banner"/>').append(
-        $('<a/>', {
-          title: 'Docket is available for free from RECAP.',
-          href: result.docket_url
-        }).append(
-          $('<img/>', {src: chrome.extension.getURL('assets/images/icon-16.png')})
-        ).append(
-          ' Get this docket as of ' + result.timestamp + ' for free from RECAP.'
-        )
-      ).append(
-        $('<br><small>Note that archived dockets may be out of date.</small>')
-      ).appendTo($('form'));
-    }
-  });
-}
+content_delegate.handleDocketQueryUrl();
 
-if (!(history.state && history.state.uploaded)) {
-  // If this is a docket page, upload it to RECAP.
-  if (PACER.isDocketDisplayUrl(url)) {
-    var casenum = PACER.getCaseNumberFromUrl(document.referrer);
-    if (casenum) {
-      var filename = PACER.getBaseNameFromUrl(url).replace('.pl', '.html');
-      recap.uploadDocket(court, casenum, filename, 'text/html',
-                         document.documentElement.innerHTML, function (ok) {
-        if (ok) {
-          history.replaceState({uploaded: 1});
-          notifier.showUpload(
-            'Docket uploaded to the public archive.',
-            function(){}
-          );
-        }
-      });
-    }
-  }
+// If this is a docket page, upload it to RECAP.
+content_delegate.handleDocketDisplayPage();
 
-  // If this is a document's menu of attachments (subdocuments), upload it to
-  // RECAP.
-  if (PACER.isAttachmentMenuPage(url, document)) {
-    recap.uploadAttachmentMenu(
-      court,
-      window.location.pathname,
-      'text/html',
-      document.documentElement.innerHTML,
-      function (ok) {
-        if (ok) {
-          history.replaceState({uploaded: 1});
-          notifier.showUpload(
-           'Menu page uploaded to the public archive.',
-            function () {}
-          );
-        }
-      }
-    );
-  }
-}
+// If this is a document's menu of attachments (subdocuments), upload it to
+// RECAP.
+content_delegate.handleAttachmentMenuPage();
 
 // If this page offers a single document, ask RECAP whether it has the document.
-if (PACER.isSingleDocumentPage(url, document)) {
-  recap.getAvailabilityForDocuments([url], function (result) {
-    if (result && result[url]) {
-      // Insert a RECAP download link at the bottom of the form.
-      $('<div class="recap-banner"/>').append(
-        $('<a/>', {
-          title: 'Document is available for free from RECAP.',
-          href: result[url].filename
-        }).append(
-          $('<img/>', {src: chrome.extension.getURL('assets/images/icon-16.png')})
-        ).append(
-          ' Get this document for free from RECAP.'
-        )
-      ).appendTo($('form'));
-    }
-  });
-}
+content_delegate.handleSingleDocumentPage();
 
 // If this page offers a single document, intercept navigation to the document
 // view page.  The "View Document" button calls the goDLS() function, which

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -112,7 +112,7 @@ ContentDelegate.prototype.handleSingleDocumentPage = function() {
     return;
   }
 
-  this.recap.getAvailabilityForDocuments([this.url], function (result) {
+  var callback = $.proxy(function (result) {
     if (!(result && result[this.url])) {
       return;
     }
@@ -128,5 +128,7 @@ ContentDelegate.prototype.handleSingleDocumentPage = function() {
         ' Get this document for free from RECAP.'
       )
     ).appendTo($('form'));
-  });
+  }, this);
+
+  this.recap.getAvailabilityForDocuments([this.url], callback);
 };

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -119,7 +119,7 @@ ContentDelegate.prototype.handleSingleDocumentPage = function() {
     $('<div class="recap-banner"/>').append(
       $('<a/>', {
         title: 'Document is available for free from RECAP.',
-        href: result[url].filename
+        href: result[this.url].filename
       }).append(
         $('<img/>', {src: chrome.extension.getURL('assets/images/icon-16.png')})
       ).append(

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -89,20 +89,19 @@ ContentDelegate.prototype.handleAttachmentMenuPage = function() {
     return;
   }
 
-  this.recap.uploadAttachmentMenu(
-    this.court,
-    window.location.pathname,
-    'text/html',
-    document.documentElement.innerHTML,
-    function (ok) {
-      if (ok) {
-        history.replaceState({uploaded: 1});
-        this.notifier.showUpload(
-         'Menu page uploaded to the public archive.',
-          function () {}
-        );
-      }
+  var callback = $.proxy(function(ok) {
+    if (ok) {
+      history.replaceState({uploaded: true});
+      this.notifier.showUpload(
+        'Menu page uploaded to the public archive.',
+        function () {}
+      );
     }
+  }, this);
+
+  this.recap.uploadAttachmentMenu(
+    this.court, window.location.pathname, 'text/html',
+    document.documentElement.innerHTML, callback
   );
 };
 

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -62,9 +62,7 @@ ContentDelegate.prototype.handleDocketDisplayPage = function() {
     return;
   }
 
-  var filename = PACER.getBaseNameFromUrl(url).replace('.pl', '.html');
-  this.recap.uploadDocket(this.court, this.casenum, filename, 'text/html',
-                     document.documentElement.innerHTML, function (ok) {
+  var callback = $.proxy(function (ok) {
     if (ok) {
       history.replaceState({uploaded: true});
       this.notifier.showUpload(
@@ -72,7 +70,12 @@ ContentDelegate.prototype.handleDocketDisplayPage = function() {
         function(){}
       );
     }
-  });
+  }, this);
+
+  
+  var filename = PACER.getBaseNameFromUrl(this.url).replace('.pl', '.html');
+  this.recap.uploadDocket(this.court, this.casenum, filename, 'text/html',
+                          document.documentElement.innerHTML, callback);
 }
 
 // If this is a document's menu of attachments (subdocuments), upload it to

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -1,0 +1,130 @@
+// This file is part of RECAP for Chrome.
+// Copyright 2013 Ka-Ping Yee <ping@zesty.ca>
+//
+// RECAP for Chrome is free software: you can redistribute it and/or modify it
+// under the terms of the GNU General Public License as published by the Free
+// Software Foundation, either version 3 of the License, or (at your option)
+// any later version.  RECAP for Chrome is distributed in the hope that it will
+// be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+// Public License for more details.
+//
+// You should have received a copy of the GNU General Public License along with
+// RECAP for Chrome.  If not, see: http://www.gnu.org/licenses/
+
+// -------------------------------------------------------------------------
+// Abstraction of content scripts to make them modular and testable.
+
+var notifier = importInstance(Notifier);
+var toolbar_button = importInstance(ToolbarButton);
+var pacer = importInstance(Pacer);
+var recap = importInstance(Recap);
+
+ContentDelegate = function(url, court, casenum) {
+  this.url = url;
+  this.court = court;
+  this.casenum = casenum;
+};
+
+// If this is a docket query page, ask RECAP whether it has the docket page.
+ContentDelegate.prototype.handleDocketQueryUrl = function() {
+  if (!PACER.isDocketQueryUrl(this.url)) {
+    return;
+  }
+
+  recap.getAvailabilityForDocket(
+    court, PACER.getCaseNumberFromUrl(this.url), function (result) {
+    if (result && result.docket_url) {
+      // Insert a RECAP download link at the bottom of the form.
+      $('<div class="recap-banner"/>').append(
+        $('<a/>', {
+          title: 'Docket is available for free from RECAP.',
+          href: result.docket_url
+        }).append(
+          $('<img/>', {src: chrome.extension.getURL('assets/images/icon-16.png')})
+        ).append(
+          ' Get this docket as of ' + result.timestamp + ' for free from RECAP.'
+        )
+      ).append(
+        $('<br><small>Note that archived dockets may be out of date.</small>')
+      ).appendTo($('form'));
+    }
+  });
+};
+
+// If this is a docket page, upload it to RECAP.
+ContentDelegate.prototype.handleDocketDisplayPage = function() {
+  if (history.state && history.state.uploaded) {
+    return;
+  }
+
+  if (!(PACER.isDocketDisplayUrl(this.url) && this.casenum)) {
+    return;
+  }
+
+  var filename = PACER.getBaseNameFromUrl(url).replace('.pl', '.html');
+  recap.uploadDocket(this.court, this.casenum, filename, 'text/html',
+                     document.documentElement.innerHTML, function (ok) {
+    if (ok) {
+      history.replaceState({uploaded: true});
+      notifier.showUpload(
+        'Docket uploaded to the public archive.',
+        function(){}
+      );
+    }
+  });
+}
+
+// If this is a document's menu of attachments (subdocuments), upload it to
+// RECAP.
+ContentDelegate.prototype.handleAttachmentMenuPage = function() {
+  if (history.state && history.state.uploaded) {
+    return;
+  }
+
+  if (!PACER.isAttachmentMenuPage(this.url, document)) {
+    return;
+  }
+
+  recap.uploadAttachmentMenu(
+    this.court,
+    window.location.pathname,
+    'text/html',
+    document.documentElement.innerHTML,
+    function (ok) {
+      if (ok) {
+        history.replaceState({uploaded: 1});
+        notifier.showUpload(
+         'Menu page uploaded to the public archive.',
+          function () {}
+        );
+      }
+    }
+  );
+};
+
+
+// If this page offers a single document, ask RECAP whether it has the document.
+ContentDelegate.prototype.handleSingleDocumentPage = function() {
+  if (!PACER.isSingleDocumentPage(this.url, document)) {
+    return;
+  }
+
+  recap.getAvailabilityForDocuments([this.url], function (result) {
+    if (!(result && result[this.url])) {
+      return;
+    }
+
+    // Insert a RECAP download link at the bottom of the form.
+    $('<div class="recap-banner"/>').append(
+      $('<a/>', {
+        title: 'Document is available for free from RECAP.',
+        href: result[url].filename
+      }).append(
+        $('<img/>', {src: chrome.extension.getURL('assets/images/icon-16.png')})
+      ).append(
+        ' Get this document for free from RECAP.'
+      )
+    ).appendTo($('form'));
+  });
+};

--- a/manifest.json
+++ b/manifest.json
@@ -42,6 +42,7 @@
       "toolbar_button.js",
       "pacer.js",
       "recap.js",
+      "content_delegate.js",
       "content.js"
     ],
     "run_at": "document_end"

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -1,0 +1,89 @@
+describe('The ContentDelegate class', function() {
+  var docketQueryUrl = 'https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl?531591';
+  var nonsenseUrl = 'http://something.uscourts.gov/foobar/baz';
+
+  beforeEach(function() {
+    jasmine.Ajax.install();
+  });
+
+  afterEach(function() {
+    jasmine.Ajax.uninstall();
+  });
+
+  function setupChromeSpy() {
+    window.chrome = {      
+      extension: {
+        getURL: jasmine.createSpy()
+      }
+    }
+  }
+  
+  function removeChromeSpy() {
+    delete window.chrome;
+  }
+
+
+  it('gets created with a url, court and casenum', function() {
+    var expected_url = 'https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl?531591';
+    var expected_court = 'canb';
+    var expected_casenum = '531591';
+
+    var cd = new ContentDelegate(
+      expected_url, expected_court, expected_casenum);
+    expect(cd.url).toBe(expected_url);
+    expect(cd.court).toBe(expected_court);
+    expect(cd.casenum).toBe(expected_casenum);
+  });
+
+  describe('handleDocketQueryUrl', function() {
+    beforeEach(function() {
+      setupChromeSpy();
+      var form = document.createElement('form');
+      document.body.appendChild(form);
+    });
+
+    afterEach(function() {
+      removeChromeSpy();
+      var form = document.getElementsByTagName('FORM')[0];
+      form.parentNode.removeChild(form);
+    });
+
+    it('has no effect when not on a docket query url', function() {
+      var cd = new ContentDelegate(nonsenseUrl, null, null);
+      spyOn(cd.recap, 'getAvailabilityForDocket');
+      cd.handleDocketQueryUrl();
+      expect(cd.recap.getAvailabilityForDocket).not.toHaveBeenCalled();
+    });
+
+    it('inserts the RECAP banner on an appropriate page', function() {
+      var cd = new ContentDelegate(docketQueryUrl, 'canb', '531591');
+      cd.handleDocketQueryUrl();
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        'status': 200,
+        'contentType': 'application/json',
+        'responseText': ('{"timestamp": "04\/16\/15", "docket_url": ' +
+                         '"http:\/\/www.archive.org\/download\/gov.uscourts.' +
+                         'canb.531591\/gov.uscourts.canb.531591.docket.html"}')
+      });
+      var banner = document.querySelector('.recap-banner');
+      expect(banner).not.toBeNull();
+      expect(banner.innerHTML).toContain('04/16/15');
+      var link = banner.querySelector('a');
+      expect(link).not.toBeNull();
+      expect(link.href).toBe('http://www.archive.org/download/gov.uscourts.' +
+                             'canb.531591/gov.uscourts.canb.531591.docket.html')
+    });
+
+    it('has no effect when on a docket query that has no RECAP', function() {
+      var cd = new ContentDelegate(docketQueryUrl, 'canb', '531591');
+      cd.handleDocketQueryUrl();
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        'status': 200,
+        'contentType': 'application/json',
+        'responseText': '{}'
+      });
+      var banner = document.querySelector('.recap-banner');
+      expect(banner).toBeNull();
+    });
+  });
+});

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -235,4 +235,80 @@ describe('The ContentDelegate class', function() {
       });
     });
   });
+
+  describe('handleSingleDocumentPage', function() {
+    var form;
+    beforeEach(function() {
+      form = document.createElement('form');
+      document.body.appendChild(form);
+    });
+
+    afterEach(function() {
+      form.parentNode.removeChild(form);
+    });
+
+    describe('when there is NO appropriate form', function() {
+      it('has no effect when the URL is wrong', function() {
+        var cd = new ContentDelegate(nonsenseUrl, null, null);
+        spyOn(cd.recap, 'getAvailabilityForDocuments');
+        cd.handleSingleDocumentPage();
+        expect(cd.recap.getAvailabilityForDocuments).not.toHaveBeenCalled();
+      });
+
+      it('has no effect with a proper URL', function() {
+        var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
+        spyOn(cd.recap, 'getAvailabilityForDocuments');
+        cd.handleSingleDocumentPage();
+        expect(cd.recap.getAvailabilityForDocuments).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when there IS an appropriate form', function() {
+      var input;
+      beforeEach(function() {
+        input = document.createElement('input');
+        input.value = 'View Document';
+        form.appendChild(input);
+      });
+
+      afterEach(function() {
+        form.removeChild(input);
+        form.innerHTML = '';
+      });
+
+      it('has no effect when the URL is wrong', function() {
+        var cd = new ContentDelegate(nonsenseUrl, null, null);
+        spyOn(cd.recap, 'getAvailabilityForDocuments');
+        cd.handleSingleDocumentPage();
+        expect(cd.recap.getAvailabilityForDocuments).not.toHaveBeenCalled();
+      });
+
+      it('checks availability for the page when the URL is right', function() {
+        var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
+        spyOn(cd.recap, 'getAvailabilityForDocuments');
+        cd.handleSingleDocumentPage();
+        expect(cd.recap.getAvailabilityForDocuments).toHaveBeenCalled();
+      });
+
+      it('responds to a positive result', function() {
+        var fakeDownloadUrl = 'http://download.fake/531591';
+        var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
+        var fake = function(_, callback) {
+          var response = {};
+          response[singleDocUrl] = {filename: fakeDownloadUrl};
+          callback(response);
+        };
+        spyOn(cd.recap, 'getAvailabilityForDocuments').and.callFake(fake);
+
+        cd.handleSingleDocumentPage();
+
+        expect(cd.recap.getAvailabilityForDocuments).toHaveBeenCalled();
+        var banner = document.querySelector('.recap-banner');
+        expect(banner).not.toBeNull();
+        var link = banner.querySelector('a');
+        expect(link).not.toBeNull();
+        expect(link.href).toBe(fakeDownloadUrl);
+      });
+    });
+  });
 });

--- a/test/mock-utils.js
+++ b/test/mock-utils.js
@@ -1,0 +1,6 @@
+// Overrides the importInstance method of utils.js so that it no longer relies
+// on chrome and simply returns any constructor that is passed to it.
+
+function importInstance(constructor) {
+  return constructor();
+}


### PR DESCRIPTION
This is a large complex change, even though it is largely a refactoring and there is supposed to be no changes to the functionality.

The purpose of the change is to make it so that content.js isn't just a top-level script that gets runs on each page that the extension attaches to. The way it was, it was basically untestable, because you had to run the whole script every time.

The refactoring introduces ContentDelegate which is a class that exposes methods that correspond to the methods that previously existed in content.js. Not all functions have been ported over to ContentDelegate in this pass, the more complex PDF uploading functionality will have to be done in a follow up.

To demonstrate the newfound testability of the new class, as well as to help verify that nothing has been broken, this PR also includes extensive Jasmine tests for the new class.