### PR TITLE
Refactor more of content.js and add tests

### DIFF
--- a/content.js
+++ b/content.js
@@ -22,14 +22,16 @@ var pacer = importInstance(Pacer);
 var recap = importInstance(Recap);
 
 var url = window.location.href;
+var path = window.location.pathname;
 var court = PACER.getCourtFromUrl(url);
 var casenum = PACER.getCaseNumberFromUrl(document.referrer);
+var docid = PACER.getDocumentIdFromUrl(url);
 
 // Update the toolbar button with knowledge of whether the user is logged in.
 toolbar_button.updateCookieStatus(court, document.cookie, null);
 
 // Create a delegate for handling the various states we might be in.
-var content_delegate = new ContentDelegate(url, court, casenum);
+var content_delegate = new ContentDelegate(url, path, court, casenum, docid);
 
 // If this is a docket query page, ask RECAP whether it has the docket page.
 content_delegate.handleDocketQueryUrl();
@@ -42,122 +44,12 @@ content_delegate.handleDocketDisplayPage();
 content_delegate.handleAttachmentMenuPage();
 
 // If this page offers a single document, ask RECAP whether it has the document.
-content_delegate.handleSingleDocumentPage();
+content_delegate.handleSingleDocumentPageCheck();
 
 // If this page offers a single document, intercept navigation to the document
 // view page.  The "View Document" button calls the goDLS() function, which
 // creates a <form> element and calls submit() on it, so we hook into submit().
-if (PACER.isSingleDocumentPage(url, document)) {
-  // Monkey-patch the <form> prototype so that its submit() method sends a
-  // message to this content script instead of submitting the form.  To do this
-  // in the page context instead of this script's, we inject a <script> element.
-  var script = document.createElement('script');
-  script.innerText =
-      'document.createElement("form").__proto__.submit = function () {' +
-      '  this.id = "form" + new Date().getTime();' +
-      '  window.postMessage({id: this.id}, "*");' +
-      '};';
-  document.body.appendChild(script);
-
-  // When we receive the message from the above submit method, submit the form
-  // via XHR so we can get the document before the browser does.
-  window.addEventListener('message', function (event) {
-    // Save a copy of the page source, altered so that the "View Document"
-    // button goes forward in the history instead of resubmitting the form.
-    var originalSubmit = document.forms[0].getAttribute('onsubmit');
-    document.forms[0].setAttribute('onsubmit', 'history.forward(); return !1;');
-    var previousPageHtml = document.documentElement.innerHTML;
-    document.forms[0].setAttribute('onsubmit', originalSubmit);
-    var docid = PACER.getDocumentIdFromUrl(window.location.href);
-    var path = window.location.pathname;
-
-    // Now do the form request to get to the view page.  Some PACER sites will
-    // return an HTML page containing an <iframe> that loads the PDF document;
-    // others just return the PDF document.  As we don't know whether we'll get
-    // HTML (text) or PDF (binary), we ask for an ArrayBuffer and convert later.
-    $('body').css('cursor', 'wait');
-    var form = document.getElementById(event.data.id);
-    var data = new FormData(form);
-    httpRequest(form.action, data, 'arraybuffer', function (type, ab) {
-      var blob = new Blob([new Uint8Array(ab)], {type: type});
-      // If we got a PDF, we wrap it in a simple HTML page.  This lets us treat
-      // both cases uniformly: either way we have an HTML page with an <iframe>
-      // in it, which is handled by showPdfPage (defined below).
-      if (type === 'application/pdf') {
-        showPdfPage('<style>body { margin: 0; } iframe { border: none; }' +
-                    '</style><iframe src="' + URL.createObjectURL(blob) +
-                    '" width="100%" height="100%"></iframe>');
-      } else {
-        var reader = new FileReader();
-        reader.onload = function() { showPdfPage(reader.result); };
-        reader.readAsText(blob);  // convert blob to HTML text
-      }
-
-      // Given the HTML for a page with an <iframe> in it, downloads the PDF
-      // document in the iframe, displays it in the browser, and also uploads
-      // the PDF document to RECAP.
-      function showPdfPage(html) {
-        // Find the <iframe> URL in the HTML string.
-        var match = html.match(/([^]*?)<iframe[^>]*src="(.*?)"([^]*)/);
-        if (!match) {
-          document.documentElement.innerHTML = html;
-          return;
-        }
-
-        // Show the page with a blank <iframe> while waiting for the download.
-        document.documentElement.innerHTML =
-          match[1] + '<iframe src="about:blank"' + match[3];
-
-        // Download the file from the <iframe> URL.
-        httpRequest(match[2], null, 'arraybuffer', function (type, ab) {
-          // Make the Back button redisplay the previous page.
-          window.onpopstate = function(event) {
-            if (event.state.content) {
-              document.documentElement.innerHTML = event.state.content;
-            }
-          };
-          history.replaceState({content: previousPageHtml}, '');
-
-          // Display the page with the downloaded file in the <iframe>.
-          var blob = new Blob([new Uint8Array(ab)], {type: type});
-          var blobUrl = URL.createObjectURL(blob);
-          recap.getDocumentMetadata(
-            docid, function (caseid, officialcasenum, docnum, subdocnum) {
-            var filename1 = 'gov.uscourts.' + court + '.' + caseid +
-              '.' + docnum + '.' + (subdocnum || '0') + '.pdf';
-            var filename2 = PACER.COURT_ABBREVS[court] + '_' +
-              (officialcasenum || caseid) +
-              '_' + docnum + '_' + (subdocnum || '0') + '.pdf';
-            var downloadLink = '<div id="recap-download" class="initial">' +
-              '<a href="' + blobUrl + '" download="' + filename1 + '">' +
-              'Save as ' + filename1 + '</a>' +
-              '<a href="' + blobUrl + '" download="' + filename2 + '">' +
-              'Save as ' + filename2 + '</a></div>';
-            html = match[1] + downloadLink + '<iframe onload="' +
-              'setTimeout(function() {' +
-              "  document.getElementById('recap-download').className = '';" +
-              '}, 7500)" src="' + blobUrl + '"' + match[3];
-            document.documentElement.innerHTML = html;
-            history.pushState({content: html}, '');
-          });
-
-          // Upload the file to RECAP.  We can't pass an ArrayBuffer directly
-          // to the background page, so we have to convert to a regular array.
-          var name = path.match(/[^\/]+$/)[0] + '.pdf';
-          var bytes = arrayBufferToArray(ab);
-          recap.uploadDocument(court, path, name, type, bytes, function (ok) {
-            if (ok) {
-              notifier.showUpload(
-                'PDF uploaded to the public archive.',
-                function () {}
-              );
-            }
-          });
-        });
-      }
-    });
-  }, false);
-}
+content_delegate.handleSingleDocumentPageView();
 
 // Scan the document for all the links and collect the URLs we care about.
 var links = document.body.getElementsByTagName('a');

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -1,10 +1,12 @@
 // -------------------------------------------------------------------------
 // Abstraction of content scripts to make them modular and testable.
 
-ContentDelegate = function(url, court, casenum) {
+ContentDelegate = function(url, path, court, casenum, docid) {
   this.url = url;
+  this.path = path;
   this.court = court;
   this.casenum = casenum;
+  this.docid = docid
 
   this.notifier = importInstance(Notifier);
   this.recap = importInstance(Recap);
@@ -85,15 +87,13 @@ ContentDelegate.prototype.handleAttachmentMenuPage = function() {
     }
   }, this);
 
-  this.recap.uploadAttachmentMenu(
-    this.court, window.location.pathname, 'text/html',
-    document.documentElement.innerHTML, callback
-  );
+  this.recap.uploadAttachmentMenu(this.court, this.path, 'text/html',
+                                  document.documentElement.innerHTML, callback);
 };
 
 
 // If this page offers a single document, ask RECAP whether it has the document.
-ContentDelegate.prototype.handleSingleDocumentPage = function() {
+ContentDelegate.prototype.handleSingleDocumentPageCheck = function() {
   if (!PACER.isSingleDocumentPage(this.url, document)) {
     return;
   }
@@ -117,4 +117,124 @@ ContentDelegate.prototype.handleSingleDocumentPage = function() {
   }, this);
 
   this.recap.getAvailabilityForDocuments([this.url], callback);
+};
+
+
+// Given the HTML for a page with an <iframe> in it, downloads the PDF document
+// in the iframe, displays it in the browser, and also uploads the PDF document
+// to RECAP.
+ContentDelegate.prototype.showPdfPage = function(html, previousPageHtml) {
+  // Find the <iframe> URL in the HTML string.
+  var match = html.match(/([^]*?)<iframe[^>]*src="(.*?)"([^]*)/);
+  if (!match) {
+    document.documentElement.innerHTML = html;
+    return;
+  }
+
+  // Show the page with a blank <iframe> while waiting for the download.
+  document.documentElement.innerHTML =
+    match[1] + '<iframe src="about:blank"' + match[3];
+
+  // Download the file from the <iframe> URL.
+  httpRequest(match[2], null, 'arraybuffer', function (type, ab) {
+    // Make the Back button redisplay the previous page.
+    window.onpopstate = function(event) {
+      if (event.state.content) {
+        document.documentElement.innerHTML = event.state.content;
+      }
+    };
+    history.replaceState({content: previousPageHtml}, '');
+
+    // Display the page with the downloaded file in the <iframe>.
+    var blob = new Blob([new Uint8Array(ab)], {type: type});
+    var blobUrl = URL.createObjectURL(blob);
+    this.recap.getDocumentMetadata(
+      this.docid, function (caseid, officialcasenum, docnum, subdocnum) {
+      var filename1 = 'gov.uscourts.' + court + '.' + caseid +
+        '.' + docnum + '.' + (subdocnum || '0') + '.pdf';
+      var filename2 = PACER.COURT_ABBREVS[court] + '_' +
+        (officialcasenum || caseid) +
+        '_' + docnum + '_' + (subdocnum || '0') + '.pdf';
+      var downloadLink = '<div id="recap-download" class="initial">' +
+        '<a href="' + blobUrl + '" download="' + filename1 + '">' +
+        'Save as ' + filename1 + '</a>' +
+        '<a href="' + blobUrl + '" download="' + filename2 + '">' +
+        'Save as ' + filename2 + '</a></div>';
+      html = match[1] + downloadLink + '<iframe onload="' +
+        'setTimeout(function() {' +
+        "  document.getElementById('recap-download').className = '';" +
+        '}, 7500)" src="' + blobUrl + '"' + match[3];
+      document.documentElement.innerHTML = html;
+      history.pushState({content: html}, '');
+    });
+
+    // Upload the file to RECAP.  We can't pass an ArrayBuffer directly
+    // to the background page, so we have to convert to a regular array.
+    var name = this.path.match(/[^\/]+$/)[0] + '.pdf';
+    var bytes = arrayBufferToArray(ab);
+    var onUploadOk = function (ok) {
+      if (ok) {
+        this.notifier.showUpload(
+          'PDF uploaded to the public archive.', function () {});
+      }
+    }
+    recap.uploadDocument(this.court, this.path, name, type, bytes, onUploadOk);
+  });
+}
+
+
+// If this page offers a single document, intercept navigation to the document
+// view page.  The "View Document" button calls the goDLS() function, which
+// creates a <form> element and calls submit() on it, so we hook into submit().
+ContentDelegate.prototype.handleSingleDocumentPageView = function() {
+  if (!PACER.isSingleDocumentPage(url, document)) {
+    return;
+  }
+
+  // Monkey-patch the <form> prototype so that its submit() method sends a
+  // message to this content script instead of submitting the form.  To do this
+  // in the page context instead of this script's, we inject a <script> element.
+  var script = document.createElement('script');
+  script.innerText =
+      'document.createElement("form").__proto__.submit = function () {' +
+      '  this.id = "form" + new Date().getTime();' +
+      '  window.postMessage({id: this.id}, "*");' +
+      '};';
+  document.body.appendChild(script);
+
+  // When we receive the message from the above submit method, submit the form
+  // via XHR so we can get the document before the browser does.
+  var self = this;
+  window.addEventListener('message', function (event) {
+    // Save a copy of the page source, altered so that the "View Document"
+    // button goes forward in the history instead of resubmitting the form.
+    var originalSubmit = document.forms[0].getAttribute('onsubmit');
+    document.forms[0].setAttribute('onsubmit', 'history.forward(); return !1;');
+    var previousPageHtml = document.documentElement.innerHTML;
+    document.forms[0].setAttribute('onsubmit', originalSubmit);
+
+    // Now do the form request to get to the view page.  Some PACER sites will
+    // return an HTML page containing an <iframe> that loads the PDF document;
+    // others just return the PDF document.  As we don't know whether we'll get
+    // HTML (text) or PDF (binary), we ask for an ArrayBuffer and convert later.
+    $('body').css('cursor', 'wait');
+    var form = document.getElementById(event.data.id);
+    var data = new FormData(form);
+    httpRequest(form.action, data, 'arraybuffer', function (type, ab) {
+      var blob = new Blob([new Uint8Array(ab)], {type: type});
+      // If we got a PDF, we wrap it in a simple HTML page.  This lets us treat
+      // both cases uniformly: either way we have an HTML page with an <iframe>
+      // in it, which is handled by showPdfPage (defined below).
+      if (type === 'application/pdf') {
+        var html = '<style>body { margin: 0; } iframe { border: none; }' +
+                    '</style><iframe src="' + URL.createObjectURL(blob) +
+                    '" width="100%" height="100%"></iframe>';
+        self.showPdfPage(html, previousPageHtml);
+      } else {
+        var reader = new FileReader();
+        reader.onload = function() { showPdfPage(reader.result); };
+        reader.readAsText(blob);  // convert blob to HTML text
+      }
+    });
+  }, false);
 };

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -2,6 +2,7 @@ describe('The ContentDelegate class', function() {
   var docketQueryUrl = 'https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl?531591';
   var docketDisplayUrl = ('https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl?' +
                           '101092135737069-L_1_0-1');
+  var docketDisplayPath = '/cgi-bin/DktRpt.pl?101092135737069-L_1_0-1';
   var singleDocUrl = 'https://ecf.canb.uscourts.gov/doc1/034031424909';
   var nonsenseUrl = 'http://something.uscourts.gov/foobar/baz';
 
@@ -28,14 +29,16 @@ describe('The ContentDelegate class', function() {
   });
 
 
-  it('gets created with a url, court and casenum', function() {
+  it('gets created with a url, path, court and casenum', function() {
     var expected_url = 'https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl?531591';
+    var expected_path = '/cgi-bin/DktRpt.pl?531591';
     var expected_court = 'canb';
     var expected_casenum = '531591';
 
     var cd = new ContentDelegate(
-      expected_url, expected_court, expected_casenum);
+      expected_url, expected_path, expected_court, expected_casenum);
     expect(cd.url).toBe(expected_url);
+    expect(cd.path).toBe(expected_path);
     expect(cd.court).toBe(expected_court);
     expect(cd.casenum).toBe(expected_casenum);
   });
@@ -123,7 +126,8 @@ describe('The ContentDelegate class', function() {
     });
 
     it('calls uploadDocket and responds to a positive result', function() {
-      var cd = new ContentDelegate(docketDisplayUrl, 'canb', '531591');
+      var cd = new ContentDelegate(docketDisplayUrl, docketDisplayPath,
+                                   'canb', '531591');
       spyOn(cd.notifier, 'showUpload');
       spyOn(cd.recap, 'uploadDocket').and.callFake(function(_, _, _, _, _, cb) {
         cb(true);
@@ -137,7 +141,8 @@ describe('The ContentDelegate class', function() {
     });
 
     it('calls uploadDocket and responds to a negative result', function() {
-      var cd = new ContentDelegate(docketDisplayUrl, 'canb', '531591');
+      var cd = new ContentDelegate(docketDisplayUrl, docketDisplayPath,
+                                   'canb', '531591');
       spyOn(cd.notifier, 'showUpload');
       spyOn(cd.recap, 'uploadDocket').and.callFake(function(_, _, _, _, _, cb) {
         cb(false);
@@ -236,7 +241,7 @@ describe('The ContentDelegate class', function() {
     });
   });
 
-  describe('handleSingleDocumentPage', function() {
+  describe('handleSingleDocumentPageCheck', function() {
     var form;
     beforeEach(function() {
       form = document.createElement('form');
@@ -251,14 +256,14 @@ describe('The ContentDelegate class', function() {
       it('has no effect when the URL is wrong', function() {
         var cd = new ContentDelegate(nonsenseUrl, null, null);
         spyOn(cd.recap, 'getAvailabilityForDocuments');
-        cd.handleSingleDocumentPage();
+        cd.handleSingleDocumentPageCheck();
         expect(cd.recap.getAvailabilityForDocuments).not.toHaveBeenCalled();
       });
 
       it('has no effect with a proper URL', function() {
         var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
         spyOn(cd.recap, 'getAvailabilityForDocuments');
-        cd.handleSingleDocumentPage();
+        cd.handleSingleDocumentPageCheck();
         expect(cd.recap.getAvailabilityForDocuments).not.toHaveBeenCalled();
       });
     });
@@ -279,14 +284,14 @@ describe('The ContentDelegate class', function() {
       it('has no effect when the URL is wrong', function() {
         var cd = new ContentDelegate(nonsenseUrl, null, null);
         spyOn(cd.recap, 'getAvailabilityForDocuments');
-        cd.handleSingleDocumentPage();
+        cd.handleSingleDocumentPageCheck();
         expect(cd.recap.getAvailabilityForDocuments).not.toHaveBeenCalled();
       });
 
       it('checks availability for the page when the URL is right', function() {
         var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
         spyOn(cd.recap, 'getAvailabilityForDocuments');
-        cd.handleSingleDocumentPage();
+        cd.handleSingleDocumentPageCheck();
         expect(cd.recap.getAvailabilityForDocuments).toHaveBeenCalled();
       });
 
@@ -300,7 +305,7 @@ describe('The ContentDelegate class', function() {
         };
         spyOn(cd.recap, 'getAvailabilityForDocuments').and.callFake(fake);
 
-        cd.handleSingleDocumentPage();
+        cd.handleSingleDocumentPageCheck();
 
         expect(cd.recap.getAvailabilityForDocuments).toHaveBeenCalled();
         var banner = document.querySelector('.recap-banner');

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -1,9 +1,11 @@
 describe('The ContentDelegate class', function() {
   var docketQueryUrl = 'https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl?531591';
+  var docketQueryPath = '/cgi-bin/DktRpt.pl?531591';
   var docketDisplayUrl = ('https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl?' +
                           '101092135737069-L_1_0-1');
   var docketDisplayPath = '/cgi-bin/DktRpt.pl?101092135737069-L_1_0-1';
   var singleDocUrl = 'https://ecf.canb.uscourts.gov/doc1/034031424909';
+  var singleDocPath = '/doc1/034031424909';
   var nonsenseUrl = 'http://something.uscourts.gov/foobar/baz';
 
   function setupChromeSpy() {
@@ -44,25 +46,27 @@ describe('The ContentDelegate class', function() {
   });
 
   describe('handleDocketQueryUrl', function() {
+    var form;
     beforeEach(function() {
-      var form = document.createElement('form');
+      form = document.createElement('form');
+      form.id = 'handledocketqueryurl';
       document.body.appendChild(form);
     });
 
     afterEach(function() {
-      var form = document.getElementsByTagName('FORM')[0];
       form.parentNode.removeChild(form);
     });
 
     it('has no effect when not on a docket query url', function() {
-      var cd = new ContentDelegate(nonsenseUrl, null, null);
+      var cd = new ContentDelegate(nonsenseUrl, null, null, null);
       spyOn(cd.recap, 'getAvailabilityForDocket');
       cd.handleDocketQueryUrl();
       expect(cd.recap.getAvailabilityForDocket).not.toHaveBeenCalled();
     });
 
     it('inserts the RECAP banner on an appropriate page', function() {
-      var cd = new ContentDelegate(docketQueryUrl, 'canb', '531591');
+      var cd = new ContentDelegate(
+        docketQueryUrl, docketQueryPath, 'canb', '531591');
       cd.handleDocketQueryUrl();
       jasmine.Ajax.requests.mostRecent().respondWith({
         'status': 200,
@@ -81,7 +85,8 @@ describe('The ContentDelegate class', function() {
     });
 
     it('has no effect when on a docket query that has no RECAP', function() {
-      var cd = new ContentDelegate(docketQueryUrl, 'canb', '531591');
+      var cd = new ContentDelegate(
+        docketQueryUrl, docketQueryPath, 'canb', '531591');
       cd.handleDocketQueryUrl();
       jasmine.Ajax.requests.mostRecent().respondWith({
         'status': 200,
@@ -160,6 +165,7 @@ describe('The ContentDelegate class', function() {
     var form;
     beforeEach(function() {
       form = document.createElement('form');
+      form.id='handleattachmentmenupage';
       document.body.appendChild(form);
     });
 
@@ -176,7 +182,8 @@ describe('The ContentDelegate class', function() {
       });
 
       it('has no effect with a proper URL', function() {
-        var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
+        var cd = new ContentDelegate(
+          singleDocUrl, singleDocPath, 'canb', '531591');
         spyOn(cd.recap, 'uploadAttachmentMenu');
         cd.handleAttachmentMenuPage();
         expect(cd.recap.uploadAttachmentMenu).not.toHaveBeenCalled();
@@ -203,14 +210,16 @@ describe('The ContentDelegate class', function() {
       });
 
       it('uploads the page when the URL is right', function() {
-        var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
+        var cd = new ContentDelegate(
+          singleDocUrl, singleDocPath, 'canb', '531591');
         spyOn(cd.recap, 'uploadAttachmentMenu');
         cd.handleAttachmentMenuPage();
         expect(cd.recap.uploadAttachmentMenu).toHaveBeenCalled();
       });
 
       it('calls the upload method and responds to positive result', function() {
-        var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
+        var cd = new ContentDelegate(
+          singleDocUrl, singleDocPath, 'canb', '531591');
         uploadFake = function(_, _, _, _, callback) {
           callback(true);
         };
@@ -225,7 +234,8 @@ describe('The ContentDelegate class', function() {
       });
 
       it('calls the upload method and responds to negative result', function() {
-        var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
+        var cd = new ContentDelegate(
+          singleDocUrl, singleDocPath, 'canb', '531591');
         uploadFake = function(_, _, _, _, callback) {
           callback(false);
         };
@@ -245,6 +255,7 @@ describe('The ContentDelegate class', function() {
     var form;
     beforeEach(function() {
       form = document.createElement('form');
+      form.id = 'handlesingledocumentpagecheck';
       document.body.appendChild(form);
     });
 
@@ -254,14 +265,15 @@ describe('The ContentDelegate class', function() {
 
     describe('when there is NO appropriate form', function() {
       it('has no effect when the URL is wrong', function() {
-        var cd = new ContentDelegate(nonsenseUrl, null, null);
+        var cd = new ContentDelegate(nonsenseUrl, null, null, null);
         spyOn(cd.recap, 'getAvailabilityForDocuments');
         cd.handleSingleDocumentPageCheck();
         expect(cd.recap.getAvailabilityForDocuments).not.toHaveBeenCalled();
       });
 
       it('has no effect with a proper URL', function() {
-        var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
+        var cd = new ContentDelegate(
+          singleDocUrl, singleDocPath, 'canb', '531591');
         spyOn(cd.recap, 'getAvailabilityForDocuments');
         cd.handleSingleDocumentPageCheck();
         expect(cd.recap.getAvailabilityForDocuments).not.toHaveBeenCalled();
@@ -289,7 +301,8 @@ describe('The ContentDelegate class', function() {
       });
 
       it('checks availability for the page when the URL is right', function() {
-        var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
+        var cd = new ContentDelegate(
+          singleDocUrl, singleDocPath, 'canb', '531591');
         spyOn(cd.recap, 'getAvailabilityForDocuments');
         cd.handleSingleDocumentPageCheck();
         expect(cd.recap.getAvailabilityForDocuments).toHaveBeenCalled();
@@ -297,7 +310,8 @@ describe('The ContentDelegate class', function() {
 
       it('responds to a positive result', function() {
         var fakeDownloadUrl = 'http://download.fake/531591';
-        var cd = new ContentDelegate(singleDocUrl, 'canb', '531591');
+        var cd = new ContentDelegate(
+          singleDocUrl, singleDocPath, 'canb', '531591');
         var fake = function(_, callback) {
           var response = {};
           response[singleDocUrl] = {filename: fakeDownloadUrl};
@@ -314,6 +328,102 @@ describe('The ContentDelegate class', function() {
         expect(link).not.toBeNull();
         expect(link.href).toBe(fakeDownloadUrl);
       });
+    });
+  });
+
+  describe('handleSingleDocumentPageView', function() {
+    var form;
+    beforeEach(function() {
+      form = document.createElement('form');
+      form.id = 'handlesingledocumentpageview';
+      document.body.appendChild(form);
+    });
+
+    afterEach(function() {
+      form.parentNode.removeChild(form);
+    });
+
+    describe('when there is NO appropriate form', function() {
+      it('has no effect when the URL is wrong', function() {
+        var cd = new ContentDelegate(nonsenseUrl, null, null, null);
+        spyOn(document, 'createElement');
+        cd.handleSingleDocumentPageView();
+        expect(document.createElement).not.toHaveBeenCalled();
+      });
+
+      it('has no effect with a proper URL', function() {
+        var cd = new ContentDelegate(
+          singleDocUrl, singleDocPath, 'canb', '531591');
+        spyOn(cd.recap, 'getAvailabilityForDocuments');
+        cd.handleSingleDocumentPageView();
+        expect(cd.recap.getAvailabilityForDocuments).not.toHaveBeenCalled();
+      });
+    });
+
+    describe('when there IS an appropriate form', function() {
+      var input;
+      beforeEach(function() {
+        input = document.createElement('input');
+        input.value = 'View Document';
+        form.appendChild(input);
+      });
+
+      afterEach(function() {
+        form.removeChild(input);
+        form.innerHTML = '';
+      });
+
+      it('creates a non-empty script element', function() {
+        var cd = new ContentDelegate(
+          singleDocUrl, singleDocPath, 'canb', '531591');
+        var scriptSpy = {};
+        spyOn(document, 'createElement').and.returnValue(scriptSpy);
+        spyOn(document.body, 'appendChild');
+        cd.handleSingleDocumentPageView();
+
+        expect(document.createElement).toHaveBeenCalledWith('script');
+        expect(scriptSpy.innerText).toEqual(jasmine.any(String));
+        expect(document.body.appendChild).toHaveBeenCalledWith(scriptSpy);
+      });
+
+      it('adds an event listener for the message in the script', function() {
+        var cd = new ContentDelegate(
+          singleDocUrl, singleDocPath, 'canb', '531591');
+        spyOn(window, 'addEventListener');
+        cd.handleSingleDocumentPageView();
+
+        expect(window.addEventListener).toHaveBeenCalledWith(
+          'message', jasmine.any(Function), false);
+      });
+    });
+  });
+
+  describe('onDocumentViewSubmit', function() {
+    var form;
+    var form_id = '1234';
+    var event = {data: {id: form_id}};
+    beforeEach(function() {
+      form = document.createElement('form');
+      form.id = form_id;
+      document.body.appendChild(form);
+    });
+
+    afterEach(function() {
+      form.parentNode.removeChild(form);
+    });
+
+    it('sets the onsubmit attribute of the page form', function() {
+      var expected_on_submit = 'expectedOnSubmit();';
+      form.setAttribute('onsubmit', expected_on_submit);
+      spyOn(form, 'setAttribute');
+      var cd = new ContentDelegate(
+        singleDocUrl, singleDocPath, 'canb', '531591');
+      cd.onDocumentViewSubmit(event);
+
+      expect(form.setAttribute).toHaveBeenCalledWith(
+        'onsubmit', 'history.forward(); return !1;')
+      expect(form.setAttribute).toHaveBeenCalledWith(
+        'onsubmit', expected_on_submit)
     });
   });
 });


### PR DESCRIPTION
This PR refactors the part of content.js that is concerned with downloading PDF files, and adds tests for the same.

This part was left for its own PR because of the complexity of the PDF handling code. This code has several nested asynchronous functions. saves entire HTML documents in local variables, manipulates the state of the browser history, and asynchronously downloads then uploads PDF data.

Generally, the strategy employed was to separate the major functionality of this function and extract helper instance methods from several of the embedded functions that were defined inline. To this end, the functions ContentDelegate.showPdfPage and ContentDelegate.onDocumentViewSubmit were created. Liberal use was made of the "bind" browser function in order to assure that the proper object context was used when those functions are eventually called.

This PR was tested manually for both courts that return PDF and HTML documents.