### PR TITLE
Create a gen204 call for logging purposes and its first usage.

### DIFF
--- a/content.js
+++ b/content.js
@@ -57,6 +57,15 @@ var urls = [];
 for (var i = 0; i < links.length; i++) {
   if (PACER.isDocumentUrl(links[i].href)) {
     urls.push(links[i].href);
+    if (PACER.isConvertibleDocumentUrl(links[i].href)) {
+      // Do this here because the mouseover logic is crazy and who knows if
+      // anyone will actually mouseover a show_doc link if one appears.
+      recap.gen204({
+        'event': 'convertible_doc',
+        'doc_url': links[i].href,
+        'page_url': window.location.href
+      }, function() {});  // The export thing annoyingly requires a callback.
+    }
   }
   links[i].addEventListener('mouseover', function () {
     if (PACER.isConvertibleDocumentUrl(this.href)) {

--- a/recap.js
+++ b/recap.js
@@ -45,6 +45,26 @@ function Recap() {
   };
 
   return {
+    // For logging purposes, this method generates a call to the server's
+    // gen204 endpoint.
+    gen204: function(params, cb) {
+      var url =  SERVER_ROOT.replace(/recap$/, 'gen204');
+      if (params) {
+        url += '?';
+      }
+      for (key in params) {
+        if (params.hasOwnProperty(key)) {
+          url += (encodeURIComponent(key) + '=' +
+                  encodeURIComponent(params[key]) + '&');
+        }
+      }
+      if (params) {
+        // Remove the extra &.
+        url = url.substring(0, url.length - 1);
+      }
+      httpRequest(url, null, 'text', cb);
+    },
+
     // Asks RECAP whether it has a docket page for the specified case.  If it
     // is available, the callback will be called with a {docket_url: ...,
     // timestamp: ...} object, where the "docket_url" field gives the URL at

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -276,4 +276,39 @@ describe('The Recap export module', function() {
       expect(actualData).toEqual(expected);
     });
   });
+
+  describe('gen204', function() {
+    it('generates the right ping URL with simple parameters', function() {
+      var params = {
+        'foo': 'bar',
+        'baz': 42
+      };
+      recap.gen204(params);
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
+        'https://recapextension.org/gen204?foo=bar&baz=42');
+    });
+
+    it('generates an empty URL with no parameters', function() {
+      recap.gen204();
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
+        'https://recapextension.org/gen204');
+    });
+
+    it('URL encodes its parameters', function() {
+      recap.gen204({'desc/': 'This is the desc'});
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
+        'https://recapextension.org/gen204?desc%2F=This%20is%20the%20desc');
+    });
+
+    it('Handles URLs in parameters', function() {
+      recap.gen204({
+        'location': 'https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl?531479'
+      });
+      expect(jasmine.Ajax.requests.mostRecent().url).toBe(
+        'https://recapextension.org/gen204?' +
+        'location=https%3A%2F%2Fecf.canb.uscourts.gov%2Fcgi-bin%2FDktRpt.pl' +
+        '%3F531479');
+
+    });
+  });
 });

--- a/utils.js
+++ b/utils.js
@@ -120,8 +120,13 @@ function httpRequest(url, postData, responseType, callback) {
       callback && callback(type, result);
     }
   };
-  xhr.open(postData === null ? 'GET' : 'POST', url);
-  xhr.send(postData);
+  if (postData) {
+    xhr.open('POST', url);
+    xhr.send(postData);
+  } else {
+    xhr.open('GET', url);
+    xhr.send();
+  }
 }
 
 // Converts an ArrayBuffer to a regular array of unsigned bytes.  Array.apply()


### PR DESCRIPTION
The riskiest part of this change is the slight tweak to utils.js and the send method, so that if the formData is null it is not sent. I clicked around and things seemed to be working.

Otherwise, the gen204 method takes an Object that specifies parameters and does a GET request to the server's gen204 endpoint. I also added the specific event that we wish to log.

Thanks!