### PR TITLE
toolbar_button.js: Guard items['options']

### DIFF
--- a/toolbar_button.js
+++ b/toolbar_button.js
@@ -45,7 +45,7 @@ function updateToolbarButton(tab) {
       setDefaultOptions({});
     }
 
-    if (items['options']['recap_disabled']){
+    if (items && items['options'] && items['options']['recap_disabled']){
       setTitleIcon('RECAP is temporarily disabled', {
         '19': 'assets/images/disabled-19.png',
         '38': 'assets/images/disabled-38.png'


### PR DESCRIPTION
Address traceback issue raised in (but collateral to) #202.

Only necessary for FF56, but sometimes we can get megaspew (scores) of tracebacks on stderr:

Extension error: TypeError: items.options is undefined moz-extension://0aca09aa-5baf-6545-88c1-9246114796ab/toolbar_button.js 48
[[Exception stack
updateToolbarButton/<@moz-extension://0aca09aa-5baf-6545-88c1-9246114796ab/toolbar_button.js:48:1
Current stack
runSafeSyncWithoutClone@resource://gre/modules/ExtensionUtils.jsm:63:129
runSafeSync@resource://gre/modules/ExtensionUtils.jsm:94:37
runSafe@resource://gre/modules/ExtensionCommon.jsm:164:32
wrapPromise/<@resource://gre/modules/ExtensionCommon.jsm:353:13
]]