### PR TITLE
Miscellaneous cleanup from Dec. 11, 2017 commits

### DIFF
--- a/content_delegate.js
+++ b/content_delegate.js
@@ -49,10 +49,9 @@ ContentDelegate.prototype.findAndStorePacerDocIds = function() {
 
       let onclick = link.getAttribute('onclick');
       let goDLS = PACER.parseGoDLSFunction(onclick);
-      let de_caseid = goDLS.de_caseid;
-      if (de_caseid) {
-        docsToCases[pacer_doc_id] = de_caseid;
-        debug(3, 'Y doc ' + pacer_doc_id + ' to ' + de_caseid);
+      if (goDLS.de_caseid) {
+        docsToCases[pacer_doc_id] = goDLS.de_caseid;
+        debug(3, 'Y doc ' + pacer_doc_id + ' to ' + goDLS.de_caseid);
       } else if (page_pacer_case_id) {
         docsToCases[pacer_doc_id] = page_pacer_case_id;
         debug(3,'X doc ' + pacer_doc_id + ' to '

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -48,8 +48,8 @@ ContentDelegate.prototype.findAndStorePacerDocIds = function() {
       this.pacer_doc_ids.push(pacer_doc_id);
 
       let onclick = link.getAttribute('onclick');
-      let goDls = PACER.parseGoDlsFunction(onclick);
-      let de_caseid = goDls.de_caseid;
+      let goDLS = PACER.parseGoDLSFunction(onclick);
+      let de_caseid = goDLS.de_caseid;
       if (de_caseid) {
         docsToCases[pacer_doc_id] = de_caseid;
         debug(3, 'Y doc ' + pacer_doc_id + ' to ' + de_caseid);

--- a/pacer.js
+++ b/pacer.js
@@ -143,7 +143,7 @@ let PACER = {
       // JS is trash. It lacks a way of getting the TLD, so we use endsWith.
       if (hostname.endsWith('uscourts.gov')) {
         for (let re of [
-          /[?&]caseid=(\d+)/,  // match on caseid GET param
+          /[?&]caseid=(\d+)/i, // match on caseid GET param
           /\?(\d+)(?:&.*)?$/,  // match on DktRpt.pl?178502&blah urls
         ]){
           let match = url.match(re);

--- a/pacer.js
+++ b/pacer.js
@@ -139,10 +139,9 @@ let PACER = {
           let match = url.match(re);
           if (match){
             if (match[1] === '0'){
-              // This is somehow matching the caseId GET param from appellate
-              // PACER, which often has a value like caseId=0 in the URL. We
-              // don't want that. Press on.
-              continue
+              // Appellate CMECF calls District CMECF with caseId=0 when it doesn't
+              // know the caseid. Ignore that special case here.
+              continue;
             }
             return match[1];
           }

--- a/pacer.js
+++ b/pacer.js
@@ -134,7 +134,7 @@ let PACER = {
       if (hostname.endsWith('uscourts.gov')) {
         for (let re of [
           /[?&]caseid=(\d+)/,  // match on caseid GET param
-          /\?(\d+)(?:&.*)?$/   // match on DktRpt.pl?178502&blah urls
+          /\?(\d+)(?:&.*)?$/,  // match on DktRpt.pl?178502&blah urls
         ]){
           let match = url.match(re);
           if (match){

--- a/pacer.js
+++ b/pacer.js
@@ -181,19 +181,14 @@ let PACER = {
     // as:
     //   function goDLS(hyperlink, de_caseid, de_seqno, got_receipt,
     //                  pdf_header, pdf_toggle_possible, magic_num, hdr)
-    let [, hyperlink, de_caseid, de_seqno, got_receipt,
-      pdf_header, pdf_toggle_possible, magic_num, hdr]
-      = goDLS_string.match(/^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/);
-    return {
-      'hyperlink': hyperlink,
-      'de_caseid': de_caseid,
-      'de_seqno': de_seqno,
-      'got_receipt': got_receipt,
-      'pdf_header': pdf_header,
-      'pdf_toggle_possible': pdf_toggle_possible,
-      'magic_num': magic_num,
-      'hdr': hdr
+    let goDLS = goDLS_string.match(/^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/);
+    if (!goDLS) {
+      return false;
     }
+    let r = {};
+    [, r.hyperlink, r.de_caseid, r.de_seqno, r.got_receipt,
+	 r.pdf_header, r.pdf_toggle_possible, r.magic_num, r.hdr] = goDLS;
+    return r;
   },
 
   // Given document.cookie, returns true if the user is logged in to PACER.

--- a/pacer.js
+++ b/pacer.js
@@ -50,6 +50,8 @@ let PACER = {
 
   // Returns true if the given URL looks like a link to a PACER document.
   isDocumentUrl: function (url) {
+    // xxx isSingleDocumentPage() and isDocumentURL() use the same regexp.
+    // this suggests an abstraction problem.
     if (
         url.match(/\/doc1\/\d+/) ||
         url.match(/\/cgi-bin\/show_doc/)
@@ -92,6 +94,8 @@ let PACER = {
   // Returns true if this is a page for downloading a single document.
   isSingleDocumentPage: function (url, document) {
     let inputs = document.getElementsByTagName('input');
+    // xxx isSingleDocumentPage() and isDocumentURL() use the same regexp.
+    // this suggests an abstraction problem.
     let pageCheck = (
                      url.match(/\/doc1\/\d+/) ||
                      url.match(/\/cgi-bin\/show_doc/

--- a/pacer.js
+++ b/pacer.js
@@ -121,8 +121,8 @@ let PACER = {
       if (inputs.length && last_input.value === 'View Document') {
         // Grab the document ID from the form's onsubmit attribute
         let onsubmit = last_input.form.getAttribute('onsubmit');
-        let goDls = PACER.parseGoDlsFunction(onsubmit);
-        return PACER.getDocumentIdFromUrl(goDls.hyperlink);
+        let goDLS = PACER.parseGoDLSFunction(onsubmit);
+        return PACER.getDocumentIdFromUrl(goDLS.hyperlink);
       }
     }
   },
@@ -162,7 +162,7 @@ let PACER = {
   },
 
   // Parse the goDLS function returning its parameters as a dict.
-  parseGoDlsFunction: function (goDLS_string){
+  parseGoDLSFunction: function (goDLS_string){
     // CMECF provides extra information on Document Links (DLS?) in the goDLS()
     // function of an onclick handler, e.g.:
     //

--- a/pacer.js
+++ b/pacer.js
@@ -148,6 +148,7 @@ let PACER = {
         ]){
           let match = url.match(re);
           if (match){
+            debug(3, "Found caseid via: " + match[0]);
             if (match[1] === '0'){
               // Appellate CMECF calls District CMECF with caseId=0 when it doesn't
               // know the caseid. Ignore that special case here.

--- a/pacer.js
+++ b/pacer.js
@@ -50,7 +50,10 @@ let PACER = {
 
   // Returns true if the given URL looks like a link to a PACER document.
   isDocumentUrl: function (url) {
-    if (url.match(/\/doc1\/\d+/) || url.match(/\/cgi-bin\/show_doc/)) {
+    if (
+        url.match(/\/doc1\/\d+/) ||
+        url.match(/\/cgi-bin\/show_doc/)
+    ) {
       if (PACER.getCourtFromUrl(url)) {
         return true;
       }
@@ -89,7 +92,10 @@ let PACER = {
   // Returns true if this is a page for downloading a single document.
   isSingleDocumentPage: function (url, document) {
     let inputs = document.getElementsByTagName('input');
-    let pageCheck = (url.match(/\/doc1\/\d+/) || url.match(/\/cgi-bin\/show_doc/)) &&
+    let pageCheck = (
+                     url.match(/\/doc1\/\d+/) ||
+                     url.match(/\/cgi-bin\/show_doc/
+    )) &&
       inputs.length &&
       inputs[inputs.length - 1].value === 'View Document';
     return !!pageCheck;


### PR DESCRIPTION
Keep regexps on a single line.
Ensure terminal comma on the final line of multiline arrays so future patches are clean.
Ensure statements end in semicolons.
Correct log message from a99f6562f1f646f6508202870035027c70200ede.
Clarify comment regarding Appellate use of caseId.
Consistently use goDLS over goDls (either way we must be consistent. There's a good argument for this one though, I think).
Eliminate unnecessary temp variable.
String.prototype.match() can fail, and when it does, it will cause a TypeError from array destructuring if we don't check. Correct that.
Be smart when destructuring to an object -- don't use a pile of temp vars and repeat them, just destructure into the object directly.
debuglog the source of caseids per discussion at d8754eb#commitcomment-26188087
Match the `caseid` parameter case-insensitively per same