### PR TITLE
content_delegate.js: Narrow scope of auth warning

### DIFF
--- a/content_delegate.js
+++ b/content_delegate.js
@@ -477,7 +477,7 @@ ContentDelegate.prototype.handleRecapLinkClick = function(window_obj, url) {
         'RECAP is not affiliated with the U.S. Courts. The documents ' +
         'it makes available are voluntarily uploaded by PACER users. ' +
         'RECAP cannot guarantee the authenticity of documents because the ' +
-        'courts themselves provide no document authentication system.</small>')
+        'courts provide no effective document authentication system.</small>')
     ).appendTo($('body'));
   });
   return false;


### PR DESCRIPTION
This revises the warning Ka-Ping added in 2013 (02bcc53) to be accurate.

The "courts" do indeed provide document authentication systems. At
bottom, of course, one can redownload the document in PACER, for a
fee, or otherwise obtain it from the Court.

But perhaps more relevantly, CM/ECF does offer a cryptographic hash
service, but it is not useful because: it is restricted by ACL to
filing users only (and is not availble to PACER users who just try the
URL); the hash procedure is not publicly documented; and, at least
superficially, it appears to require a key that is not public
available.

So instead we say there is "no effective document authentication system,"
not "no document authentication system."

<hr>

I seem to recall we had talked about this earlier and potentially the popup was going away? I have no opinion in that, but obviously the popup isn't going away expeditiously, so it might as well tell the truth while it is here.
  