### PR TITLE
goDLS() checks

### DIFF
--- a/content_delegate.js
+++ b/content_delegate.js
@@ -50,7 +50,7 @@ ContentDelegate.prototype.findAndStorePacerDocIds = function() {
       let onclick = link.getAttribute('onclick');
       let goDLS = PACER.parseGoDLSFunction(onclick);
 
-      if (goDLS.de_caseid) {
+      if (goDLS && goDLS.de_caseid) {
         docsToCases[pacer_doc_id] = goDLS.de_caseid;
         debug(3, 'Y doc ' + pacer_doc_id + ' to ' + goDLS.de_caseid);
       } else if (page_pacer_case_id) {

--- a/pacer.js
+++ b/pacer.js
@@ -257,7 +257,7 @@ let PACER = {
     // as:
     //   function goDLS(hyperlink, de_caseid, de_seqno, got_receipt,
     //                  pdf_header, pdf_toggle_possible, magic_num, hdr)
-    let goDLS = goDLS_string.match(/^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/);
+    let goDLS = /^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/.exec(goDLS_string);
     if (!goDLS) {
       return false;
     }

--- a/pacer.js
+++ b/pacer.js
@@ -167,7 +167,7 @@ let PACER = {
         // Grab the document ID from the form's onsubmit attribute
         let onsubmit = last_input.form.getAttribute('onsubmit');
         let goDLS = PACER.parseGoDLSFunction(onsubmit);
-        return PACER.getDocumentIdFromUrl(goDLS.hyperlink);
+        return goDLS && PACER.getDocumentIdFromUrl(goDLS.hyperlink);
       }
     }
   },
@@ -231,7 +231,7 @@ let PACER = {
         // Download receipt page.
         let onsubmit = last_input.form.getAttribute("onsubmit");
         let goDLS = PACER.parseGoDLSFunction(onsubmit);
-        return goDLS.de_caseid;
+        return goDLS && goDLS.de_caseid;
       }
     }
   },

--- a/pacer.js
+++ b/pacer.js
@@ -259,7 +259,7 @@ let PACER = {
     //                  pdf_header, pdf_toggle_possible, magic_num, hdr)
     let goDLS = /^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/.exec(goDLS_string);
     if (!goDLS) {
-      return false;
+      return null;
     }
     let r = {};
     [, r.hyperlink, r.de_caseid, r.de_seqno, r.got_receipt, r.pdf_header,

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -236,15 +236,15 @@ describe('The PACER module', function() {
     });
 
     it("returns false for an invalid DLS string", function() {
-      expect(PACER.parseGoDLSFunction("not a goDLS function call")).toBe(false);
+      expect(PACER.parseGoDLSFunction("not a goDLS function call")).toBe(null);
     });
 
     it("returns false for a null DLS input", function() {
-      expect(PACER.parseGoDLSFunction(null)).toBe(false);
+      expect(PACER.parseGoDLSFunction(null)).toBe(null);
     });
 
     it("returns false for an undefined DLS input", function() {
-      expect(PACER.parseGoDLSFunction(undefined)).toBe(false);
+      expect(PACER.parseGoDLSFunction(undefined)).toBe(null);
     });
 
   });

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -234,6 +234,19 @@ describe('The PACER module', function() {
         hdr: ''
       });
     });
+
+    it("returns false for an invalid DLS string", function() {
+      expect(PACER.parseGoDLSFunction("not a goDLS function call")).toBe(false);
+    });
+
+    it("returns false for a null DLS input", function() {
+      expect(PACER.parseGoDLSFunction(null)).toBe(false);
+    });
+
+    it("returns false for an undefined DLS input", function() {
+      expect(PACER.parseGoDLSFunction(undefined)).toBe(false);
+    });
+
   });
 
   describe('hasPacerCookie', function() {


### PR DESCRIPTION
Fixes https://github.com/freelawproject/recap/issues/231
Do not assume that `parseGoDLSFunction()` will always be called with a string — it might be called with `null`.

Also ensure all its callers are prepared to deal with failure (false).

Add corresponding tests for these issues.