### PR TITLE
Fixes claim doc1 URLs 

### DIFF
--- a/content_delegate.js
+++ b/content_delegate.js
@@ -228,10 +228,6 @@ ContentDelegate.prototype.onDocumentViewSubmit = function (event) {
   // Save a copy of the page source, altered so that the "View Document"
   // button goes forward in the history instead of resubmitting the form.
   let form = document.getElementById(event.data.id);
-  let originalSubmit = form.getAttribute('onsubmit');
-  form.setAttribute('onsubmit', 'history.forward(); return false;');
-  let previousPageHtml = document.documentElement.innerHTML;
-  form.setAttribute('onsubmit', originalSubmit);
 
   // Grab the document number, attachment number, and docket number
   let document_number, attachment_number, docket_number;
@@ -240,12 +236,22 @@ ContentDelegate.prototype.onDocumentViewSubmit = function (event) {
     let image_string = $('td:contains(Image)').text();
     let regex = /(\d+)-(\d+)/;
     let matches = regex.exec(image_string);
+    if (!matches) {
+      // This happens on bankruptcy claim pages, which are a form of document in
+      // CM/ECF that we don't want. In this case, just submit the original form.
+      form.submit();
+    }
     document_number = matches[1];
     attachment_number = matches[2];
     docket_number = $.trim($('tr:contains(Case Number) td:nth(1)').text());
   } else { // Appellate
     debug(4,"Appellate parsing not yet implemented");
   }
+
+  let originalSubmit = form.getAttribute('onsubmit');
+  form.setAttribute('onsubmit', 'history.forward(); return false;');
+  let previousPageHtml = document.documentElement.innerHTML;
+  form.setAttribute('onsubmit', originalSubmit);
 
   // Now do the form request to get to the view page.  Some PACER sites will
   // return an HTML page containing an <iframe> that loads the PDF document;

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -227,7 +227,11 @@ ContentDelegate.prototype.handleSingleDocumentPageCheck = function() {
 ContentDelegate.prototype.onDocumentViewSubmit = function (event) {
   // Save a copy of the page source, altered so that the "View Document"
   // button goes forward in the history instead of resubmitting the form.
-  let form = document.getElementById(event.data.id);
+  let originalForm = document.forms[0];
+  let originalSubmit = originalForm.getAttribute('onsubmit');
+  originalForm.setAttribute('onsubmit', 'history.forward(); return false;');
+  let previousPageHtml = document.documentElement.innerHTML;
+  originalForm.setAttribute('onsubmit', originalSubmit);
 
   // Grab the document number, attachment number, and docket number
   let document_number, attachment_number, docket_number;
@@ -248,16 +252,12 @@ ContentDelegate.prototype.onDocumentViewSubmit = function (event) {
     debug(4,"Appellate parsing not yet implemented");
   }
 
-  let originalSubmit = form.getAttribute('onsubmit');
-  form.setAttribute('onsubmit', 'history.forward(); return false;');
-  let previousPageHtml = document.documentElement.innerHTML;
-  form.setAttribute('onsubmit', originalSubmit);
-
   // Now do the form request to get to the view page.  Some PACER sites will
   // return an HTML page containing an <iframe> that loads the PDF document;
   // others just return the PDF document.  As we don't know whether we'll get
   // HTML (text) or PDF (binary), we ask for an ArrayBuffer and convert later.
   $('body').css('cursor', 'wait');
+  let form = document.getElementById(event.data.id);
   let data = new FormData(form);
   httpRequest(form.action, data, function (type, ab, xhr) {
     console.info('RECAP: Successfully submitted RECAP "View" button form: ' +

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -240,11 +240,6 @@ ContentDelegate.prototype.onDocumentViewSubmit = function (event) {
     let image_string = $('td:contains(Image)').text();
     let regex = /(\d+)-(\d+)/;
     let matches = regex.exec(image_string);
-    if (!matches) {
-      // This happens on bankruptcy claim pages, which are a form of document in
-      // CM/ECF that we don't want. In this case, just submit the original form.
-      form.submit();
-    }
     document_number = matches[1];
     attachment_number = matches[2];
     docket_number = $.trim($('tr:contains(Case Number) td:nth(1)').text());

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -233,13 +233,20 @@ ContentDelegate.prototype.onDocumentViewSubmit = function (event) {
   let previousPageHtml = document.documentElement.innerHTML;
   originalForm.setAttribute('onsubmit', originalSubmit);
 
+  let form = document.getElementById(event.data.id);
+
   // Grab the document number, attachment number, and docket number
   let document_number, attachment_number, docket_number;
 
   if (!PACER.isAppellateCourt(this.court)) {
+    // This CSS selector duplicated in isSingleDocumentPage
     let image_string = $('td:contains(Image)').text();
     let regex = /(\d+)-(\d+)/;
     let matches = regex.exec(image_string);
+    if (!matches){
+      form.submit();
+      return;
+    }
     document_number = matches[1];
     attachment_number = matches[2];
     docket_number = $.trim($('tr:contains(Case Number) td:nth(1)').text());
@@ -252,7 +259,6 @@ ContentDelegate.prototype.onDocumentViewSubmit = function (event) {
   // others just return the PDF document.  As we don't know whether we'll get
   // HTML (text) or PDF (binary), we ask for an ArrayBuffer and convert later.
   $('body').css('cursor', 'wait');
-  let form = document.getElementById(event.data.id);
   let data = new FormData(form);
   httpRequest(form.action, data, function (type, ab, xhr) {
     console.info('RECAP: Successfully submitted RECAP "View" button form: ' +

--- a/content_delegate.js
+++ b/content_delegate.js
@@ -227,11 +227,11 @@ ContentDelegate.prototype.handleSingleDocumentPageCheck = function() {
 ContentDelegate.prototype.onDocumentViewSubmit = function (event) {
   // Save a copy of the page source, altered so that the "View Document"
   // button goes forward in the history instead of resubmitting the form.
-  let originalSubmit = document.forms[0].getAttribute('onsubmit');
-  document.forms[0].setAttribute('onsubmit',
-				 'history.forward(); return false;');
+  let form = document.getElementById(event.data.id);
+  let originalSubmit = form.getAttribute('onsubmit');
+  form.setAttribute('onsubmit', 'history.forward(); return false;');
   let previousPageHtml = document.documentElement.innerHTML;
-  document.forms[0].setAttribute('onsubmit', originalSubmit);
+  form.setAttribute('onsubmit', originalSubmit);
 
   // Grab the document number, attachment number, and docket number
   let document_number, attachment_number, docket_number;
@@ -252,7 +252,6 @@ ContentDelegate.prototype.onDocumentViewSubmit = function (event) {
   // others just return the PDF document.  As we don't know whether we'll get
   // HTML (text) or PDF (binary), we ask for an ArrayBuffer and convert later.
   $('body').css('cursor', 'wait');
-  let form = document.getElementById(event.data.id);
   let data = new FormData(form);
   httpRequest(form.action, data, function (type, ab, xhr) {
     console.info('RECAP: Successfully submitted RECAP "View" button form: ' +

--- a/pacer.js
+++ b/pacer.js
@@ -139,7 +139,11 @@ let PACER = {
   isSingleDocumentPage: function (url, document) {
     let inputs = document.getElementsByTagName('input');
     let lastInput = inputs.length && inputs[inputs.length - 1].value;
+    // If the receipt doesn't say "Image" we don't yet support it on the server.
+    // So far, this only appears to apply to bankruptcy claims.
+    let hasImageReceipt = !!$('td:contains(Image)').length;
     let pageCheck = (PACER.isDocumentUrl(url) &&
+                     hasImageReceipt &&
                      (lastInput === 'View Document') ||
                      (lastInput === 'Accept Charges and Retrieve'));
     debug(4," lastInput "+lastInput);

--- a/pacer.js
+++ b/pacer.js
@@ -140,7 +140,8 @@ let PACER = {
     let inputs = document.getElementsByTagName('input');
     let lastInput = inputs.length && inputs[inputs.length - 1].value;
     // If the receipt doesn't say "Image" we don't yet support it on the server.
-    // So far, this only appears to apply to bankruptcy claims.
+    // So far, this only appears to apply to bankruptcy claims. This CSS
+    // selector is duplicated in onDocumentViewSubmit.
     let hasImageReceipt = !!$('td:contains(Image)').length;
     let pageCheck = (PACER.isDocumentUrl(url) &&
                      hasImageReceipt &&

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -339,6 +339,14 @@ describe('The ContentDelegate class', function() {
         input = document.createElement('input');
         input.value = 'View Document';
         form.appendChild(input);
+
+        table = document.createElement('table');
+        tr = document.createElement('tr');
+        td = document.createElement('td');
+        td.appendChild(document.createTextNode('Image'));
+        tr.appendChild(td);
+        table.appendChild(tr);
+        document.body.appendChild(table);
       });
 
       afterEach(function() {
@@ -429,6 +437,14 @@ describe('The ContentDelegate class', function() {
         input = document.createElement('input');
         input.value = 'View Document';
         form.appendChild(input);
+
+        table = document.createElement('table');
+        tr = document.createElement('tr');
+        td = document.createElement('td');
+        td.appendChild(document.createTextNode('Image'));
+        tr.appendChild(td);
+        table.appendChild(tr);
+        document.body.appendChild(table);
       });
 
       afterEach(function() {
@@ -663,7 +679,7 @@ describe('The ContentDelegate class', function() {
         expect(window_obj.location).toBe(linkUrl);
       });
     });
-    
+
     describe('when the popup option is set', function() {
       beforeEach(function() {
         window.chrome =  {
@@ -739,7 +755,7 @@ describe('The ContentDelegate class', function() {
         cd.attachRecapLinkToEligibleDocs();
         expect($('.recap-inline').length).toBe(0);
       });
-      
+
       it('attaches a single link to the one url with recap', function() {
         spyOn(cd.recap, 'getAvailabilityForDocuments').and.callFake(
           function(_, _, callback) {


### PR DESCRIPTION
Prior to this fix, we'd try to send bankruptcy claim documents to the RECAP Archive. Normally we want all the documents in PACER, but these documents are an example of documents that we *don't* want since they're not even part of the docket. 

I wouldn't normally worry too much about an esoteric type of document on an esoteric type of the legal world (bankruptcy stuff), but this particular bug made it so that the document itself couldn't be downloaded at all. Breaking PACER is not OK, so this fixes that.