### PR TITLE
refactor(recap): Moves one function to use a listener as an example

### DIFF
--- a/content_delegate.js
+++ b/content_delegate.js
@@ -372,8 +372,6 @@ ContentDelegate.prototype.showPdfPage = function(
         let uploadDocument = function(items){
           if (!items['options']['recap_disabled']) {
             // If we have the pacer_case_id, upload the file to RECAP.
-            // We can't pass an ArrayBuffer directly to the background
-            // page, so we have to convert to a regular array.
             let onUploadOk = function (ok) {
               if (ok) {
                 this.notifier.showUpload(
@@ -387,10 +385,18 @@ ContentDelegate.prototype.showPdfPage = function(
             // array and pass that, then convert back to a blob when
             // we add the data to the FormData object.
             let bytes = arrayBufferToArray(ab);
-            this.recap.uploadDocument(
-              this.court, pacer_case_id, this.pacer_doc_id, document_number,
-              attachment_number, bytes, onUploadOk
-            );
+            chrome.runtime.sendMessage({
+              package: 'recap',
+              function: 'uploadDocument',
+              args: {
+                pacer_court: this.court,
+                pacer_case_id: pacer_case_id,
+                pacer_doc_id: this.pacer_doc_id,
+                document_number: document_number,
+                attachment_number: attachment_number,
+                bytes: bytes,
+              },
+            }, onUploadOk);
           } else {
             console.info("RECAP: Not uploading PDF. RECAP is disabled.");
           }

--- a/recap.js
+++ b/recap.js
@@ -1,16 +1,17 @@
+var DEBUG = false, // When true, don't publish what's sent to the archive.
+  SERVER_ROOT = 'https://www.courtlistener.com/api/rest/v3/',
+  UPLOAD_TYPES = {
+    'DOCKET': 1,
+    'ATTACHMENT_PAGE': 2,
+    'PDF': 3,
+    'DOCKET_HISTORY_REPORT': 4,
+    'APPELLATE_DOCKET': 5,
+    'APPELLATE_ATTACHMENT_PAGE': 6,
+  };
+
 // Abstraction of the RECAP server APIs.
-// Public impure functions.  (See utils.js for details on defining services.)
 function Recap() {
-  var DEBUG=false, // When true, don't publish what's sent to the archive.
-    SERVER_ROOT = 'https://www.courtlistener.com/api/rest/v3/',
-    UPLOAD_TYPES = {
-      'DOCKET': 1,
-      'ATTACHMENT_PAGE': 2,
-      'PDF': 3,
-      'DOCKET_HISTORY_REPORT': 4,
-      'APPELLATE_DOCKET': 5,
-      'APPELLATE_ATTACHMENT_PAGE': 6,
-    };
+
 
   return {
     //Given a pacer_doc_id, return the pacer_case_id that it is associated with
@@ -131,43 +132,54 @@ function Recap() {
         }
       });
     },
-
-    // Uploads a PDF document to the RECAP server, calling the callback with
-    // a boolean success flag.
-    uploadDocument: function(pacer_court, pacer_case_id, pacer_doc_id,
-                             document_number, attachment_number, bytes, cb) {
-      console.info(`RECAP: Attempting PDF upload to RECAP Archive with details: ` +
-                   `pacer_court: ${pacer_court}, pacer_case_id: ` +
-                   `${pacer_case_id}, pacer_doc_id: ${pacer_doc_id}, ` +
-                   `document_number: ${document_number}, ` +
-                   `attachment_number: ${attachment_number}.`);
-      let formData = new FormData();
-      formData.append('court', PACER.convertToCourtListenerCourt(pacer_court));
-      pacer_case_id && formData.append('pacer_case_id', pacer_case_id);
-      pacer_doc_id && formData.append('pacer_doc_id', pacer_doc_id);
-      document_number && formData.append('document_number', document_number);
-      if (attachment_number && attachment_number !== '0'){
-        formData.append('attachment_number', attachment_number);
-      }
-      formData.append('filepath_local', new Blob([new Uint8Array(bytes)]));
-      formData.append('upload_type', UPLOAD_TYPES['PDF']);
-      formData.append('debug', DEBUG);
-      $.ajax({
-        url: SERVER_ROOT + 'recap/',
-        method: 'POST',
-        processData: false,
-        contentType: false,
-        data: formData,
-        success: function(data, textStatus, xhr){
-          console.info(`RECAP: Successfully uploaded PDF: '${textStatus}' ` +
-                       `with processing queue id of ${data['id']}`);
-          cb(data || null);
-        },
-        error: function(xhr, textStatus, errorThrown){
-          console.error(`RECAP: Ajax error uploading PDF. Status: ${textStatus}.` +
-                        `Error: ${errorThrown}`);
-        }
-      });
-    },
   };
 }
+
+
+
+chrome.runtime.onMessage.addListener(function(request, sender, cb){
+  if (request.package !== 'recap'){
+    // Namespace this code under the recap name.
+    return;
+  }
+  let args = request.args;
+
+  // Uploads a PDF document to the RECAP server, calling the callback with
+  // a boolean success flag.
+  if (request.function === 'uploadDocument'){
+    console.info(`RECAP: Attempting PDF upload to RECAP Archive with details: ` +
+      `pacer_court: ${args.pacer_court}, pacer_case_id: ` +
+      `${args.pacer_case_id}, pacer_doc_id: ${args.pacer_doc_id}, ` +
+      `document_number: ${args.document_number}, ` +
+      `attachment_number: ${args.attachment_number}.`);
+    let formData = new FormData();
+    formData.append('court', PACER.convertToCourtListenerCourt(args.pacer_court));
+    args.pacer_case_id && formData.append('pacer_case_id', args.pacer_case_id);
+    args.pacer_doc_id && formData.append('pacer_doc_id', args.pacer_doc_id);
+    args.document_number && formData.append('document_number', args.document_number);
+    if (args.attachment_number && args.attachment_number !== '0') {
+      formData.append('attachment_number', args.attachment_number);
+    }
+    formData.append('filepath_local', new Blob([new Uint8Array(args.bytes)]));
+    formData.append('upload_type', UPLOAD_TYPES['PDF']);
+    formData.append('debug', DEBUG);
+    $.ajax({
+      url: SERVER_ROOT + 'recap/',
+      method: 'POST',
+      processData: false,
+      contentType: false,
+      data: formData,
+      success: function (data, textStatus, xhr) {
+        console.info(`RECAP: Successfully uploaded PDF: '${textStatus}' ` +
+          `with processing queue id of ${data['id']}`);
+        cb(data || null);
+      },
+      error: function (xhr, textStatus, errorThrown) {
+        console.error(`RECAP: Ajax error uploading PDF. Status: ${textStatus}.` +
+          `Error: ${errorThrown}`);
+      }
+    });
+  }
+  return true;  // allow cb to be called after listener returns
+
+});


### PR DESCRIPTION
## BACKGROUND

This is a step in the direction of nuking importInstance and
exportInstance, and towards doing things the "normal" way, via message
passing and listening.

As mentioned in freelawproject/recap#237, the way we're doing this now
makes it difficult to use certain functions, because those functions
can only be used in background scripts that are not *also* content
scripts. Since I need one of those functions to support zip upload in
freelawproject/recap#117, I'm working to get this fixed.

The only alternative to this that I could think of was to create a new
file called recap_background.js, which would be a background-only script
and then put my code in there, but I didn't love that approach since it
separated things arbitrarily.

## IMPLEMENTATION

The way I've implemented this is to move the uploadDocument function
out of Recap(), and to put it under a listener at the bottom of the
file. This listener checks for a package name of "recap", and then uses
an if statement to listen for a function mame of "uploadDocument". The
idea here is that I will move *all* of the existing functions in the
Recap() object into this listener, and it will use the package check and
function name check to run the right code.

I've done a bit of research on this approach, and it appears that
there's no right way to do this. This approach feels fairly clean to me
though, so I think I'm comfortable going with it. Other approaches
I considered were:

 - Using one listener per function. I like how this would allow us to
   have a cleaner separation of the functions (they're not just
   separated by if statements, but I didn't like how this would mean a
   lot of repetition of the package/function filtering within the
   beginning of each listener.

 - Using a simpler approach to function/package filtering. Could the
   function name just be "recap.uploadDocument" for example instead of
   using to keys in the object that we pass to the listener?

 - A few other things that aren't coming to mind right now (it's late).

## BIG QUESTIONS

1. Can I refactor all of the functions to this format without breaking
   things? This is a big refactor, and thus dangerous. Going to need
   test coverage.

2. Is there a way we can simplify sendMessage? We went from 4 lines and
   one function call to 12 lines and one function call. That's not
   great.

3. What about tests? How do we pull this apart so that it's easy to
   also refactor the tests. This seems painful.