### PR TITLE
 Add tests that all Recap methods send AJAX requests with debug=false

### DIFF
--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -133,6 +133,42 @@ describe('The Recap export module', function() {
     });
   });
 
+  describe('uploadDocket, uploadAttachmentMenu, uploadDocument', function() {
+    var existingFormData;
+    beforeEach(function() {
+      setupChromeSpy();
+      existingFormData = window.FormData;
+      window.FormData = FormDataFake;
+    });
+    
+    afterEach(function() {
+      window.FormData = existingFormData;
+      removeChromeSpy();
+    });
+
+    var bytes = new Uint8Array([100, 100, 200, 200, 300]);
+
+    it('all send debug=false in AJAX request', function() {
+      expected = new FormDataFake();
+      expected.append('debug', false);
+
+      recap.uploadDocket(court, pacer_case_id, html, 'DOCKET', function() {});
+      var actualData = jasmine.Ajax.requests.mostRecent().data();
+      expect(actualData).toEqual(jasmine.objectContaining(expected));
+
+      recap.uploadAttachmentMenu(court, pacer_case_id, html, function() {});
+      var actualData = jasmine.Ajax.requests.mostRecent().data();
+      expect(actualData).toEqual(jasmine.objectContaining(expected));
+
+      recap.uploadDocument(
+        court, pacer_case_id, pacer_doc_id, docnum, attachnum, bytes,
+        function() {});
+      var actualData = jasmine.Ajax.requests.mostRecent().data();
+      expect(actualData).toEqual(jasmine.objectContaining(expected));
+    });
+  });
+
+
   describe('uploadDocket', function() {
     var existingFormData;
     beforeEach(function() {

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -140,7 +140,7 @@ describe('The Recap export module', function() {
       existingFormData = window.FormData;
       window.FormData = FormDataFake;
     });
-    
+
     afterEach(function() {
       window.FormData = existingFormData;
       removeChromeSpy();
@@ -148,23 +148,21 @@ describe('The Recap export module', function() {
 
     var bytes = new Uint8Array([100, 100, 200, 200, 300]);
 
-    it('all send debug=false in AJAX request', function() {
-      expected = new FormDataFake();
-      expected.append('debug', false);
-
+    it('all send debug=false in AJAX request. If this test fails, it likely means DEBUG=true is set in ' + 
+           'recap', function() {
       recap.uploadDocket(court, pacer_case_id, html, 'DOCKET', function() {});
       var actualData = jasmine.Ajax.requests.mostRecent().data();
-      expect(actualData).toEqual(jasmine.objectContaining(expected));
+      expect(actualData['debug']).toBe(false);
 
       recap.uploadAttachmentMenu(court, pacer_case_id, html, function() {});
       var actualData = jasmine.Ajax.requests.mostRecent().data();
-      expect(actualData).toEqual(jasmine.objectContaining(expected));
+      expect(actualData['debug']).toBe(false);
 
       recap.uploadDocument(
         court, pacer_case_id, pacer_doc_id, docnum, attachnum, bytes,
         function() {});
       var actualData = jasmine.Ajax.requests.mostRecent().data();
-      expect(actualData).toEqual(jasmine.objectContaining(expected));
+      expect(actualData['debug']).toBe(false)
     });
   });
 


### PR DESCRIPTION
Follow up from #46. The idea is that if a developer were to accidentally leave DEBUG = true in their recap.js file, the tests would break. But in general, when changing that parameter, only this test breaks.