### PR TITLE
feat(recap): Sends the installed version to any URL in the manifest.

### DIFF
--- a/content.js
+++ b/content.js
@@ -40,3 +40,11 @@ if (PACER.hasPacerCookie(document.cookie)) {
 } else {
   console.info(`RECAP: Taking no actions because not logged in: `+url);
 }
+
+// Dispatch a message to every URL that's in the manifest to say that RECAP is
+// installed.
+let currentVersion = chrome.runtime.getManifest().version;
+window.postMessage({
+  sender: "recap-extension",
+  message: currentVersion
+}, "*");

--- a/content.js
+++ b/content.js
@@ -40,4 +40,3 @@ if (PACER.hasPacerCookie(document.cookie)) {
 } else {
   console.info(`RECAP: Taking no actions because not logged in: `+url);
 }
-

--- a/content.js
+++ b/content.js
@@ -41,10 +41,3 @@ if (PACER.hasPacerCookie(document.cookie)) {
   console.info(`RECAP: Taking no actions because not logged in: `+url);
 }
 
-// Dispatch a message to every URL that's in the manifest to say that RECAP is
-// installed.
-let currentVersion = chrome.runtime.getManifest().version;
-window.postMessage({
-  sender: "recap-extension",
-  message: currentVersion
-}, "*");

--- a/install_notifier.js
+++ b/install_notifier.js
@@ -1,7 +1,12 @@
 // Dispatch a message to every URL that's in the manifest to say that RECAP is
-// installed.
-let currentVersion = chrome.runtime.getManifest().version;
-window.postMessage({
-  sender: "recap-extension",
-  message: currentVersion
-}, "*");
+// installed.  This allows webpages to take action based on the presence of the
+// extension and its version. This is only allowed for a small whitelist of
+// domains defined in the manifest.
+(function () {
+  let currentVersion = chrome.runtime.getManifest().version;
+  window.postMessage({
+    sender: "recap-extension",
+    message_name: "version",
+    message: currentVersion
+  }, "*");
+})();

--- a/install_notifier.js
+++ b/install_notifier.js
@@ -1,0 +1,7 @@
+// Dispatch a message to every URL that's in the manifest to say that RECAP is
+// installed.
+let currentVersion = chrome.runtime.getManifest().version;
+window.postMessage({
+  sender: "recap-extension",
+  message: currentVersion
+}, "*");

--- a/manifest.json
+++ b/manifest.json
@@ -38,9 +38,7 @@
     ]
   },
   "content_scripts": [{
-    "matches": [
-      "*://*.uscourts.gov/*"
-    ],
+    "matches": ["*://*.uscourts.gov/*"],
     "include_globs": ["*://ecf.*", "*://ecf-train.*", "*://pacer.*"],
     "css": [
       "assets/css/style.css",

--- a/manifest.json
+++ b/manifest.json
@@ -39,11 +39,9 @@
   },
   "content_scripts": [{
     "matches": [
-      "*://*.uscourts.gov/*",
-      "https://www.courtlistener.com/*",
-      "http://localhost/*",
-      "http://127.0.0.1/*"
+      "*://*.uscourts.gov/*"
     ],
+    "include_globs": ["*://ecf.*", "*://ecf-train.*", "*://pacer.*"],
     "css": [
       "assets/css/style.css",
       "assets/css/font-awesome.css"
@@ -60,6 +58,16 @@
       "recap.js",
       "content_delegate.js",
       "content.js"
+    ],
+    "run_at": "document_end"
+  }, {
+    "matches": [
+      "https://www.courtlistener.com/*",
+      "http://localhost/*",
+      "http://127.0.0.1/*"
+    ],
+    "js": [
+      "install_notifier.js"
     ],
     "run_at": "document_end"
   }],

--- a/manifest.json
+++ b/manifest.json
@@ -38,8 +38,12 @@
     ]
   },
   "content_scripts": [{
-    "matches": ["*://*.uscourts.gov/*"],
-    "include_globs": ["*://ecf.*", "*://ecf-train.*", "*://pacer.*"],
+    "matches": [
+      "*://*.uscourts.gov/*",
+      "https://www.courtlistener.com/*",
+      "http://localhost/*",
+      "http://127.0.0.1/*"
+    ],
     "css": [
       "assets/css/style.css",
       "assets/css/font-awesome.css"

--- a/manifest.json
+++ b/manifest.json
@@ -59,11 +59,7 @@
     ],
     "run_at": "document_end"
   }, {
-    "matches": [
-      "https://www.courtlistener.com/*",
-      "http://localhost/*",
-      "http://127.0.0.1/*"
-    ],
+    "matches": ["https://www.courtlistener.com/*"],
     "js": [
       "install_notifier.js"
     ],

--- a/manifest.json
+++ b/manifest.json
@@ -63,7 +63,7 @@
     "js": [
       "install_notifier.js"
     ],
-    "run_at": "document_end"
+    "run_at": "document_idle"
   }],
   "browser_action": {
     "default_icon": {


### PR DESCRIPTION
Pretty basic changes here. All we do is set up the extension to send the version string to any website where it's running and tweak the manifest to send that to a few new places:

 - https://www.courtlistener.com
 - locahost & 127.0.0.1
 - removes the `include_globs` which would normally filter the domain further (this has the side effect of making RECAP work across all of uscourts.gov instead of only on certain domains/urls).

Fixes: freelawproject/recap#215.