### PR TITLE
Fix donate link

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -80,10 +80,14 @@
   </p>
 
   <div id="donate-plea" class="text-center">
-    <a href="https://free.law/donate/?referrer=recap-extension" target="_blank">
+    <a href="https://free.law/donate/?referrer=recap-extension"
+      target="_blank"
+      rel="noopener">
       <img alt="Donate to support the Free Law Project" class="pad20" src="assets/images/donate-button.png">
     </a>
-    <a href="https://free.law/recap/" target="_blank">
+    <a href="https://free.law/recap/"
+      target="_blank"
+      rel="noopener">
       <img alt="free.law/recap" class="pad20" src="assets/images/recap-logo-143x85.png">
     </a>
   </div>
@@ -91,17 +95,20 @@
   <div class="text-center">
     <a href="https://twitter.com/freelawproject"
        class="fa-stack fa-lg"
-       target="_blank">
+       target="_blank"
+       rel="noopener">
       <i class="fa fa-circle fa-stack-2x gray"></i>
       <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
     </a>
     <a href="https://free.law/newsletter/" class="fa-stack fa-lg"
-       target="_blank">
+       target="_blank"
+       rel="noopener">
       <i class="fa fa-circle fa-stack-2x gray"></i>
       <i class="fa fa-newspaper-o fa-stack-1x fa-inverse"></i>
     </a>
     <a href="https://www.facebook.com/freelawproject" class="fa-stack fa-lg"
-       target="_blank">
+       target="_blank"
+       rel="noopener">
       <i class="fa fa-circle fa-stack-2x gray"></i>
       <i class="fa fa-facebook fa-stack-1x fa-inverse"></i>
     </a>

--- a/src/options.html
+++ b/src/options.html
@@ -80,10 +80,10 @@
   </p>
 
   <div id="donate-plea" class="text-center">
-    <a href="https://free.law/donate/?referrer=recap-extension">
+    <a href="https://free.law/donate/?referrer=recap-extension" target="_blank">
       <img alt="Donate to support the Free Law Project" class="pad20" src="assets/images/donate-button.png">
     </a>
-    <a href="https://free.law/recap/">
+    <a href="https://free.law/recap/" target="_blank">
       <img alt="free.law/recap" class="pad20" src="assets/images/recap-logo-143x85.png">
     </a>
   </div>


### PR DESCRIPTION
The RECAP and Donate links in the extension currently don't open anything in Google Chrome (despite working fine in Firefox).  Adding `target="_blank"` is required for Chrome extensions to open new windows.