### PR TITLE
fix 235

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "recap-chrome",
-  "version": "1.2.14",
+  "version": "1.2.15",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -40,12 +40,12 @@ describe('The ContentDelegate class', function() {
       storage : {
         local : {
           get : jasmine.createSpy().and.callFake(function(
-              _, cb) { cb({options : {}}); })
+              _, cb) { cb({options : {}}); }),
+          set : jasmine.createSpy('set').and.callFake(function() {})
         }
       }
     }
   }
-
   function removeChromeSpy() {
     delete window.chrome;
   }
@@ -223,7 +223,8 @@ describe('The ContentDelegate class', function() {
           storage : {
             local : {
               get : jasmine.createSpy().and.callFake(function(
-                _, cb) { cb({options : {recap_enabled: false}}); })
+                _, cb) { cb({options : {recap_enabled: false}}); }),
+              set : jasmine.createSpy('set').and.callFake(function() {})
             }
           }
         };
@@ -247,7 +248,8 @@ describe('The ContentDelegate class', function() {
           storage : {
             local : {
               get : jasmine.createSpy().and.callFake(function(
-                _, cb) { cb({options : {recap_enabled: true}}); })
+                _, cb) { cb({options : {recap_enabled: true}}); }),
+              set : jasmine.createSpy('set').and.callFake(function() {})
             }
           }
         };
@@ -341,7 +343,8 @@ describe('The ContentDelegate class', function() {
           storage : {
             local : {
               get : jasmine.createSpy().and.callFake(function(
-                _, cb) { cb({options : {recap_enabled: false}}); })
+                _, cb) { cb({options : {recap_enabled: false}}); }),
+              set : jasmine.createSpy('set').and.callFake(function() {})
             }
           }
         };
@@ -372,7 +375,8 @@ describe('The ContentDelegate class', function() {
           storage : {
             local : {
               get : jasmine.createSpy().and.callFake(function(
-                _, cb) { cb({options : {recap_enabled: true}}); })
+                _, cb) { cb({options : {recap_enabled: true}}); }),
+              set : jasmine.createSpy('set').and.callFake(function() {})
             }
           }
         };
@@ -771,7 +775,8 @@ describe('The ContentDelegate class', function() {
         storage : {
           local : {
             get : jasmine.createSpy().and.callFake(function(
-              _, cb) { cb({options : {recap_enabled: true}}); })
+              _, cb) { cb({options : {recap_enabled: true}}); }),
+            set : jasmine.createSpy('set').and.callFake(function() {})
           }
         }
       };
@@ -984,7 +989,8 @@ describe('The ContentDelegate class', function() {
           storage : {
             local : {
               get : jasmine.createSpy().and.callFake(function(
-                  _, cb) { cb({options : {recap_link_popups : true}}); })
+                  _, cb) { cb({options : {recap_link_popups : true}}); }),
+              set : jasmine.createSpy('set').and.callFake(function() {})
             }
           }
         };

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -204,30 +204,39 @@ describe('The Recap export module', function() {
   describe('uploadDocument', function() {
     let existingFormData;
 
+    const bytes = new Uint8Array([100, 100, 200, 200, 300]);
+    const blob = new Blob([html], {type: type}, filename);
+    const nonce = 'blob_upload_storage'
+
     beforeEach(function() {
-      setupChromeSpy();
+      window.chrome = {
+        storage: {
+          local: {
+            get: jasmine.createSpy('get').and.callFake((_, cb) => cb({ [nonce]: blob })),
+            set: jasmine.createSpy('set')
+          }
+        }
+      }
       existingFormData = window.FormData;
       window.FormData = FormDataFake;
     });
 
     afterEach(function() {
       window.FormData = existingFormData;
-      removeChromeSpy();
+      delete window.chrome;
     });
 
-    const bytes = new Uint8Array([100, 100, 200, 200, 300]);
-    const blob = new Blob([html], {type: type}, filename);
-    const blobUrl = URL.createObjectUrl
 
-    it('requests the correct URL', async function() {
-      await recap.uploadDocument(
-        court, pacer_case_id, pacer_doc_id, docnum, attachnum, blobUrl,
+
+    it('requests the correct URL', function() {
+      recap.uploadDocument(
+        court, pacer_case_id, pacer_doc_id, docnum, attachnum, nonce,
         function() {});
       expect(jasmine.Ajax.requests.mostRecent().url).toBe(
         'https://www.courtlistener.com/api/rest/v3/recap/');
     });
 
-    it('sends the correct FormData', async function() {
+    it('sends the correct FormData', function() {
       const expected = new FormDataFake();
       expected.append('court', court);
       expected.append('pacer_case_id', pacer_case_id);
@@ -235,13 +244,16 @@ describe('The Recap export module', function() {
       expected.append('document_number', docnum);
       expected.append('attachment_number', attachnum);
       expected.append('upload_type', 3);
+      // intentionally omitting test of chrome storage promises
+      // we pass the actual blob to the form instead of mocking
+      // the setting and retrieval of items in chrome storage
       expected.append('filepath_local', blob)
 
       // pacer_court, pacer_case_id, pacer_doc_id,
-      // document_number, attachment_number, blobUrl, cb
+      // document_number, attachment_number, nonce, cb
 
-      await recap.uploadDocument(
-        court, pacer_case_id, pacer_doc_id, docnum, attachnum, blobUrl,
+      recap.uploadDocument(
+        court, pacer_case_id, pacer_doc_id, docnum, attachnum, nonce,
         function() {});
       const actualData = jasmine.Ajax.requests.mostRecent().data();
       expect(actualData).toEqual(jasmine.objectContaining(expected));

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -216,16 +216,18 @@ describe('The Recap export module', function() {
     });
 
     const bytes = new Uint8Array([100, 100, 200, 200, 300]);
+    const blob = new Blob([html], {type: type}, filename);
+    const blobUrl = URL.createObjectUrl
 
-    it('requests the correct URL', function() {
-      recap.uploadDocument(
-        court, pacer_case_id, pacer_doc_id, docnum, attachnum, bytes,
+    it('requests the correct URL', async function() {
+      await recap.uploadDocument(
+        court, pacer_case_id, pacer_doc_id, docnum, attachnum, blobUrl,
         function() {});
       expect(jasmine.Ajax.requests.mostRecent().url).toBe(
         'https://www.courtlistener.com/api/rest/v3/recap/');
     });
 
-    it('sends the correct FormData', function() {
+    it('sends the correct FormData', async function() {
       const expected = new FormDataFake();
       expected.append('court', court);
       expected.append('pacer_case_id', pacer_case_id);
@@ -233,14 +235,13 @@ describe('The Recap export module', function() {
       expected.append('document_number', docnum);
       expected.append('attachment_number', attachnum);
       expected.append('upload_type', 3);
-      expected.append('filepath_local', new Blob(
-        [html], {type: type}), filename);
+      expected.append('filepath_local', blob)
 
       // pacer_court, pacer_case_id, pacer_doc_id,
-      // document_number, attachment_number, bytes, cb
+      // document_number, attachment_number, blobUrl, cb
 
-      recap.uploadDocument(
-        court, pacer_case_id, pacer_doc_id, docnum, attachnum, bytes,
+      await recap.uploadDocument(
+        court, pacer_case_id, pacer_doc_id, docnum, attachnum, blobUrl,
         function() {});
       const actualData = jasmine.Ajax.requests.mostRecent().data();
       expect(actualData).toEqual(jasmine.objectContaining(expected));

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -415,8 +415,8 @@ ContentDelegate.prototype.showPdfPage = function(
     history.replaceState({content: previousPageHtml}, '');
 
     // store the result in chrome local storage
-    //
-    const nonce = "EB23C5DF"
+
+    const nonce = "blob_upload_storage"
     const data = { [nonce]: ab }
 
     chrome.storage.local.set(data, function() {

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -414,10 +414,20 @@ ContentDelegate.prototype.showPdfPage = function(
     };
     history.replaceState({content: previousPageHtml}, '');
 
+    // store the result in chrome local storage
+    //
+    const nonce = "EB23C5DF"
+    const data = { [nonce]: ab }
+
+    chrome.storage.local.set(data, function() {
+      console.log(`Blob saved: ${data.nonce.length}`)
+    })
+
     // Get the PACER case ID and, on completion, define displayPDF()
     // to either display the PDF in the provided <iframe>, or, if
     // external_pdf is set, save it using FileSaver.js's saveAs().
     let blob = new Blob([new Uint8Array(ab)], {type: type});
+
     this.recap.getPacerCaseIdFromPacerDocId(
       this.pacer_doc_id, function(pacer_case_id){
         console.info(`RECAP: Stored pacer_case_id is ${pacer_case_id}`);
@@ -468,11 +478,6 @@ ContentDelegate.prototype.showPdfPage = function(
         }.bind(this);
 
         chrome.storage.local.get('options', displayPDF);
-        const nonce = "EB23C5DF"
-        const data = { [nonce]: arrayBufferToArray(ab) }
-        chrome.storage.local.set(data, function() {
-          console.log('Blob is set to', data)
-        })
         let uploadDocument = function(items){
           // store the blob in chrome storage for background worker
           if (items['options']['recap_enabled'] && !this.restricted) {

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -482,14 +482,11 @@ ContentDelegate.prototype.showPdfPage = function(
               }
             }.bind(this);
 
-            // In Chrome, blobs can't be passed from content scripts
-            // to background scripts, so we have to convert to an
-            // array and pass that, then convert back to a blob when
-            // we add the data to the FormData object.
-            let bytes = arrayBufferToArray(ab);
+            // In modern JS, you can pass the blob through the DOM using a url
+            const blobUrl = URL.createObjectURL(blob)
             this.recap.uploadDocument(
               this.court, pacer_case_id, this.pacer_doc_id, document_number,
-              attachment_number, bytes, onUploadOk
+              attachment_number, blobUrl, onUploadOk
             );
           } else {
             console.info("RECAP: Not uploading PDF. RECAP is disabled.");

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -468,8 +468,13 @@ ContentDelegate.prototype.showPdfPage = function(
         }.bind(this);
 
         chrome.storage.local.get('options', displayPDF);
-
+        const nonce = "EB23C5DF"
+        const data = { [nonce]: arrayBufferToArray(ab) }
+        chrome.storage.local.set(data, function() {
+          console.log('Blob is set to', data)
+        })
         let uploadDocument = function(items){
+          // store the blob in chrome storage for background worker
           if (items['options']['recap_enabled'] && !this.restricted) {
             // If we have the pacer_case_id, upload the file to RECAP.
             // We can't pass an ArrayBuffer directly to the background
@@ -482,11 +487,10 @@ ContentDelegate.prototype.showPdfPage = function(
               }
             }.bind(this);
 
-            // In modern JS, you can pass the blob through the DOM using a url
-            const blobUrl = URL.createObjectURL(blob)
+
             this.recap.uploadDocument(
               this.court, pacer_case_id, this.pacer_doc_id, document_number,
-              attachment_number, blobUrl, onUploadOk
+              attachment_number, nonce, onUploadOk
             );
           } else {
             console.info("RECAP: Not uploading PDF. RECAP is disabled.");

--- a/src/recap.js
+++ b/src/recap.js
@@ -155,11 +155,9 @@ function Recap() {
         if (attachment_number && attachment_number !== '0'){
           formData.append('attachment_number', attachment_number);
         }
-        console.log(bytes[nonce])
         const ab = new Uint8Array(bytes[nonce])
-        console.log(ab)
         const blob = new Blob([ab])
-        console.log("This is the value from chrome storage", blob)
+        console.log("RECAP: Retrieved blob from storage", blob)
 
         formData.append('filepath_local', blob);
         formData.append('upload_type', UPLOAD_TYPES['PDF']);

--- a/src/recap.js
+++ b/src/recap.js
@@ -134,10 +134,10 @@ function Recap() {
       });
     },
 
-    // Uploads a PDF document to the RECAP server, calling the callback with
+    // Asynchronously uploads a PDF document to the RECAP server, calling the callback with
     // a boolean success flag.
-    uploadDocument: function(pacer_court, pacer_case_id, pacer_doc_id,
-                             document_number, attachment_number, bytes, cb) {
+    uploadDocument: async function(pacer_court, pacer_case_id, pacer_doc_id,
+                             document_number, attachment_number, blobUrl, cb) {
       console.info(`RECAP: Attempting PDF upload to RECAP Archive with details: ` +
                    `pacer_court: ${pacer_court}, pacer_case_id: ` +
                    `${pacer_case_id}, pacer_doc_id: ${pacer_doc_id}, ` +
@@ -151,7 +151,9 @@ function Recap() {
       if (attachment_number && attachment_number !== '0'){
         formData.append('attachment_number', attachment_number);
       }
-      formData.append('filepath_local', new Blob([new Uint8Array(bytes)]));
+      // wait for the window to make the blob available to the background worker
+      const blob = await fetch(blobUrl).then(res => res.blob())
+      formData.append('filepath_local', blob);
       formData.append('upload_type', UPLOAD_TYPES['PDF']);
       formData.append('debug', DEBUG);
       $.ajax({

--- a/src/recap.js
+++ b/src/recap.js
@@ -136,42 +136,53 @@ function Recap() {
 
     // Asynchronously uploads a PDF document to the RECAP server, calling the callback with
     // a boolean success flag.
-    uploadDocument: async function(pacer_court, pacer_case_id, pacer_doc_id,
-                             document_number, attachment_number, blobUrl, cb) {
+    uploadDocument: function(pacer_court, pacer_case_id, pacer_doc_id,
+                             document_number, attachment_number, nonce, cb) {
       console.info(`RECAP: Attempting PDF upload to RECAP Archive with details: ` +
                    `pacer_court: ${pacer_court}, pacer_case_id: ` +
                    `${pacer_case_id}, pacer_doc_id: ${pacer_doc_id}, ` +
                    `document_number: ${document_number}, ` +
                    `attachment_number: ${attachment_number}.`);
-      let formData = new FormData();
-      formData.append('court', PACER.convertToCourtListenerCourt(pacer_court));
-      pacer_case_id && formData.append('pacer_case_id', pacer_case_id);
-      pacer_doc_id && formData.append('pacer_doc_id', pacer_doc_id);
-      document_number && formData.append('document_number', document_number);
-      if (attachment_number && attachment_number !== '0'){
-        formData.append('attachment_number', attachment_number);
-      }
-      // wait for the window to make the blob available to the background worker
-      const blob = await fetch(blobUrl).then(res => res.blob())
-      formData.append('filepath_local', blob);
-      formData.append('upload_type', UPLOAD_TYPES['PDF']);
-      formData.append('debug', DEBUG);
-      $.ajax({
-        url: `${SERVER_ROOT}recap/`,
-        method: 'POST',
-        processData: false,
-        contentType: false,
-        data: formData,
-        success: function(data, textStatus, xhr){
-          console.info(`RECAP: Successfully uploaded PDF: '${textStatus}' ` +
-                       `with processing queue id of ${data['id']}`);
-          cb(data || null);
-        },
-        error: function(xhr, textStatus, errorThrown){
-          console.error(`RECAP: Ajax error uploading PDF. Status: ${textStatus}.` +
-                        `Error: ${errorThrown}`);
+      // wrap the upload function as the callback of the local storage retrieval
+      chrome.storage.local.get(nonce, (bytes) => {
+
+        let formData = new FormData();
+        formData.append('court', PACER.convertToCourtListenerCourt(pacer_court));
+        pacer_case_id && formData.append('pacer_case_id', pacer_case_id);
+        pacer_doc_id && formData.append('pacer_doc_id', pacer_doc_id);
+        document_number && formData.append('document_number', document_number);
+
+        if (attachment_number && attachment_number !== '0'){
+          formData.append('attachment_number', attachment_number);
         }
+        console.log(bytes[nonce])
+        const ab = new Uint8Array(bytes[nonce])
+        console.log(ab)
+        const blob = new Blob([ab])
+        console.log("This is the value from chrome storage", blob)
+
+        formData.append('filepath_local', blob);
+        formData.append('upload_type', UPLOAD_TYPES['PDF']);
+        formData.append('debug', DEBUG);
+
+        $.ajax({
+          url: `${SERVER_ROOT}recap/`,
+          method: 'POST',
+          processData: false,
+          contentType: false,
+          data: formData,
+          success: function(data, textStatus, xhr){
+            console.info(`RECAP: Successfully uploaded PDF: '${textStatus}' ` +
+                        `with processing queue id of ${data['id']}`);
+            cb(data || null);
+          },
+          error: function(xhr, textStatus, errorThrown){
+            console.error(`RECAP: Ajax error uploading PDF. Status: ${textStatus}.` +
+                          `Error: ${errorThrown}`);
+          }
+        });
+
       });
-    },
+    }
   };
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -147,18 +147,6 @@ $.ajaxSetup({
 });
 
 
-// Converts an ArrayBuffer to a regular array of unsigned bytes.  Array.apply()
-// causes a "maximum call stack size exceeded" error for buffers of only 300k,
-// so we need this ridiculous circumlocution of breaking the data into chunks.
-function arrayBufferToArray(ab) {
-  let chunks = [];
-  for (let i = 0; i < ab.byteLength; i += 100000) {
-    let slice = new Uint8Array(ab, i, Math.min(100000, ab.byteLength - i));
-    chunks.push(Array.apply(null, slice));  // convert each chunk separately
-  }
-  return [].concat.apply([], chunks);  // concatenate all the chunks together
-}
-
 // Debug logging function. First argument is a debug level, remainder are variable args
 // for console.log(). If the global debug level matches the first arg, calls console.log().
 // Example usage:

--- a/src/utils.js
+++ b/src/utils.js
@@ -146,6 +146,17 @@ $.ajaxSetup({
   }
 });
 
+// Converts an ArrayBuffer to a regular array of unsigned bytes.  Array.apply()
+// causes a "maximum call stack size exceeded" error for buffers of only 300k,
+// so we need this ridiculous circumlocution of breaking the data into chunks.
+function arrayBufferToArray(ab) {
+  let chunks = [];
+  for (let i = 0; i < ab.byteLength; i += 100000) {
+    let slice = new Uint8Array(ab, i, Math.min(100000, ab.byteLength - i));
+    chunks.push(Array.apply(null, slice));  // convert each chunk separately
+  }
+  return [].concat.apply([], chunks);  // concatenate all the chunks together
+}
 
 // Debug logging function. First argument is a debug level, remainder are variable args
 // for console.log(). If the global debug level matches the first arg, calls console.log().


### PR DESCRIPTION
Chrome reports that large PDFs exceed the permissible length in messages between the background worker and the content script. 

```
Error handling response: TypeError: Error in invocation of runtime.sendMessage(optional string extensionId, any message, optional object options, optional function responseCallback): Message length exceeded maximum allowed length.
    at Object.sender.<computed> [as uploadDocument] (chrome-extension://dndpdemfjohfjfnaahiaoknbccpghcmb/utils.js:77:24)
    at ContentDelegate.<anonymous> (chrome-extension://dndpdemfjohfjfnaahiaoknbccpghcmb/content_delegate.js:576:26)
```

This PR fixes the problem by utilizing the DOM to store the blob and passing a local URL instead of the actual blob itself to the background worker. Tested on the two links in issue 235, which now have correctly uploaded documents. 