### PR TITLE
fix(docket report): Update logic to detect docket report 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,8 +23,7 @@ jobs:
       - name: Install Dependencies
         env:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
-        with:
-          args: npm install
+        run: npm install
       - name: Test Code
         uses: mujo-code/puppeteer-headful@16.6.0
         env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,10 +20,14 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - run: npm install
+      - name: Install Dependencies
         env:
           PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
-      - run: npm test
+        with:
+          args: npm install
+      - name: Test Code
         uses: mujo-code/puppeteer-headful@16.6.0
         env:
           CI: "true"
+        with:
+          args: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,13 +20,5 @@ jobs:
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Install Dependencies
-        env:
-          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
-        run: npm install
-      - name: Test Code
-        uses: mujo-code/puppeteer-headful@16.6.0
-        env:
-          CI: "true"
-        with:
-          args: npm test
+      - run: npm install
+      - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,4 +21,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - run: npm install
+        env:
+          PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
       - run: npm test
+        uses: mujo-code/puppeteer-headful@16.6.0
+        env:
+          CI: "true"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,7 +12,7 @@ Changes:
 
 Fixes:
  - More robust uploading of attachment pages ([#304](https://github.com/freelawproject/recap/issues/304), [#238](https://github.com/freelawproject/recap/issues/238), [#291](https://github.com/freelawproject/recap/issues/291))
- - Optimized the docket report page accesed trought the reports menu ([#249](https://github.com/freelawproject/recap/issues/249))
+ - Docket reports accessed through the reports menu are now properly uploaded ([#249](https://github.com/freelawproject/recap/issues/249))
  - Failing tests are fixed ([#311](https://github.com/freelawproject/recap/issues/311)).
 
 For Developers:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
 
 Fixes:
  - More robust uploading of attachment pages ([#304](https://github.com/freelawproject/recap/issues/304), [#238](https://github.com/freelawproject/recap/issues/238), [#291](https://github.com/freelawproject/recap/issues/291))
+ - Optimized the docket report page accesed trought the reports menu ([#249](https://github.com/freelawproject/recap/issues/249))
  - Failing tests are fixed ([#311](https://github.com/freelawproject/recap/issues/311)).
 
 For Developers:

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
 // Karma configuration
 // Generated on Wed Jan 03 2018 21:51:16 GMT-0800 (PST)
 
-process.env.CHROME_BIN = process.env.PUPPETEER_EXEC_PATH;
+process.env.CHROME_BIN = require("puppeteer").executablePath();
 
 module.exports = function(config) {
   config.set({
@@ -72,7 +72,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadless'],
 
     // set these options to view logs in development
     // see https://github.com/karma-runner/karma/issues/2582#issuecomment-413660796 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
 // Karma configuration
 // Generated on Wed Jan 03 2018 21:51:16 GMT-0800 (PST)
 
-process.env.CHROME_BIN = require("puppeteer").executablePath();
+process.env.CHROME_BIN = process.env.PUPPETEER_EXEC_PATH;
 
 module.exports = function(config) {
   config.set({

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -39,7 +39,7 @@ module.exports = function(config) {
 
     // list of files / patterns to exclude
     exclude: [
-      'spec/Content*Spec.js'
+      'spec/*ZipSpec.js',
     ],
 
 
@@ -72,7 +72,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['ChromeHeadless'],
+    browsers: ['Chrome'],
 
     // set these options to view logs in development
     // see https://github.com/karma-runner/karma/issues/2582#issuecomment-413660796 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "test": "test"
   },
   "scripts": {
-    "test": "./node_modules/.bin/karma start --single-run --browsers ChromeHeadless",
+    "test": "./node_modules/.bin/karma start --single-run",
     "postinstall": "vendor-copy"
   },
   "repository": {

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -623,6 +623,7 @@ describe('The ContentDelegate class', function () {
   describe('handleSingleDocumentPageCheck', function () {
     let form;
     beforeEach(function () {
+      clearDocumentBody()
       form = document.createElement('form');
       document.body.appendChild(form);
     });

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -62,9 +62,6 @@ describe('The ContentDelegate class', function () {
       }
     }
   }
-  function removeChromeSpy() {
-    delete window.chrome;
-  }
 
   function clearDocumentBody() {
     document.body.innerHTML=''
@@ -83,7 +80,6 @@ describe('The ContentDelegate class', function () {
 
   afterEach(function () {
     jasmine.Ajax.uninstall();
-    removeChromeSpy();
     window.fetch = nativeFetch;
   });
 
@@ -280,7 +276,6 @@ describe('The ContentDelegate class', function () {
 
       afterEach(function () {
         table.remove();
-        delete window.chrome;
       });
 
       it('has no effect when recap_enabled option is false', function () {
@@ -321,7 +316,6 @@ describe('The ContentDelegate class', function () {
 
       afterEach(function () {
         table.remove();
-        delete window.chrome;
       });
 
       it('has no effect when not on a docket display url', function () {
@@ -1312,5 +1306,5 @@ describe('The ContentDelegate class', function () {
         document.querySelectorAll('.recap-inline')[0].remove();
       });
     });
-  });
+  }); 
 });

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -2,7 +2,7 @@
 describe('The ContentDelegate class', function () {
   // 'tabId' values
   const tabId = 1234;
-  
+
   // 'path' values
   const districtCourtURI = 'https://ecf.canb.uscourts.gov';
   const singleDocPath = '/doc1/034031424909';
@@ -709,7 +709,7 @@ describe('The ContentDelegate class', function () {
           spyOn(cd.recap, 'getAvailabilityForDocuments').and.callFake(fake);
 
           cd.handleSingleDocumentPageCheck();
-          
+
           expect(cd.recap.getAvailabilityForDocuments).toHaveBeenCalled();
           const banner = document.querySelectorAll('.recap-banner')[0];
           expect(banner).not.toBeNull();
@@ -1306,5 +1306,5 @@ describe('The ContentDelegate class', function () {
         document.querySelectorAll('.recap-inline')[0].remove();
       });
     });
-  }); 
+  });
 });

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -1,5 +1,6 @@
 describe('The PACER module', function() {
   const nonsenseUrl = 'http://something.uscourts.gov/foobar/baz';
+  const docketReportURL = 'https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl'
   const docketQueryUrl = ('https://ecf.canb.uscourts.gov/cgi-bin/' +
     'HistDocQry.pl?531316');
   const singleDocUrl = 'https://ecf.canb.uscourts.gov/doc1/034031424909';
@@ -135,6 +136,16 @@ describe('The PACER module', function() {
       expect(PACER.isDocketHistoryDisplayUrl(historyUrl)).toBe(true);
     });
   });
+
+  describe('formatDocketQueryUrl', function(){
+    it('should return a properly formatted URL', function () {
+      expect(PACER.formatDocketQueryUrl(docketReportURL, 365816)).toBe(docketReportURL+'?365816');
+    });
+    
+    it('should not change if not needed', function () {
+      expect(PACER.formatDocketQueryUrl(docketReportURL+'?365816', 365816)).toBe(docketReportURL+'?365816');
+    });
+  })
 
   describe('isAttachmentMenuPage', function() {
 
@@ -280,8 +291,6 @@ describe('The PACER module', function() {
         table.appendChild(tr_image);
         main.appendChild(table)
         document.body.appendChild(main)
-
-        $.fn.find = jasmine.createSpy('find').and.returnValue([td_image])
       });
 
       afterEach(function() {
@@ -305,7 +314,6 @@ describe('The PACER module', function() {
         main.appendChild(InputWithValue('Download One'))
         main.appendChild(InputWithValue('Download Some'))
         document.body.appendChild(main)
-        $.fn.find = jasmine.createSpy('find').and.returnValue([])
       });
 
       afterEach(function() {
@@ -321,7 +329,6 @@ describe('The PACER module', function() {
       beforeEach(function() {
         let main = InputContainer();
         main.appendChild(document.createElement('div'))
-        $.fn.find = jasmine.createSpy('find').and.returnValue([])
         document.body.appendChild(main)
       });
 
@@ -334,7 +341,7 @@ describe('The PACER module', function() {
       });
     })
     
-  });
+  }); 
 
   describe('getDocumentIdFromUrl', function() {
     it('returns the correct document id for a valid URL', function() {
@@ -353,19 +360,18 @@ describe('The PACER module', function() {
 
   describe('getDocumentIdFronForm', function () {
     const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','');";
-
+    let form;
     beforeEach(function() {
-      const form = document.createElement('form');
+      form = document.createElement('form');
       const input = document.createElement('input');
       input.value = 'View Document';
       form.appendChild(input);
       form.setAttribute('onSubmit', goDLS);
       document.body.appendChild(form);
-      document.getElementsByTagName = jasmine.createSpy('getElementsByTagName').and.returnValue([input])
     });
 
     afterEach(function() {
-      document.getElementsByTagName('form')[0].remove();
+      form.remove();
     });
 
     it('should return document id', function () {

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -341,7 +341,7 @@ describe('The PACER module', function() {
       });
     })
     
-  }); 
+  });
 
   describe('getDocumentIdFromUrl', function() {
     it('returns the correct document id for a valid URL', function() {

--- a/src/content.js
+++ b/src/content.js
@@ -13,46 +13,102 @@ let pacer_doc_id = PACER.getDocumentIdFromForm(url, document) ||
   PACER.getDocumentIdFromUrl(url);
 let links = document.body.getElementsByTagName('a');
 
-// seed the content_delegate with the tabId by waiting for the
-// message to return from the background worker before initializing
-getTabIdForContentScript().then(msg => {
+// seed the content_delegate with the tabId by using the message 
+// returned from the background worker
+function addRecapInformation(msg){
+    // destructure the msg object to get the tabId
+    const { tabId } = msg;
+    
+    let content_delegate = new ContentDelegate(tabId,
+      url, path, court, pacer_case_id, pacer_doc_id, links);
+  
+    if (PACER.hasPacerCookie(document.cookie)) {
+      // If this is a docket query page, ask RECAP whether it has the docket page.
+      content_delegate.handleDocketQueryUrl();
+  
+      // If this is a docket page, upload it to RECAP.
+      content_delegate.handleDocketDisplayPage();
+  
+      // If the page offers the ability to download a zip file, intercept navigation
+      // to the post-submit page.
+      content_delegate.handleZipFilePageView();
+  
+      // If this is a document's menu of attachments (subdocuments), upload it to
+      // RECAP.
+      content_delegate.handleAttachmentMenuPage();
+  
+      // If this page offers a single document, ask RECAP whether it has the document.
+      content_delegate.handleSingleDocumentPageCheck();
+  
+      // If this page offers a single document, intercept navigation to the document
+      // view page.  The "View Document" button calls the goDLS() function, which
+      // creates a <form> element and calls submit() on it, so we hook into submit().
+      content_delegate.handleSingleDocumentPageView();
+  
+      // If this is a Clams Register, we upload it to RECAP
+      content_delegate.handleClaimsPageView();
+  
+      // Check every link in the document to see if there is a free RECAP document
+      // available. If there is, put a link with a RECAP icon.
+      content_delegate.attachRecapLinkToEligibleDocs();
+    } else {
+      console.info(`RECAP: Taking no actions because not logged in: ${url}`);
+    }
+}
 
-  // destructure the msg object to get the tabId
-  const { tabId } = msg;
-
-  let content_delegate = new ContentDelegate(tabId,
-    url, path, court, pacer_case_id, pacer_doc_id, links);
-
-  if (PACER.hasPacerCookie(document.cookie)) {
-    // If this is a docket query page, ask RECAP whether it has the docket page.
-    content_delegate.handleDocketQueryUrl();
-
-    // If this is a docket page, upload it to RECAP.
-    content_delegate.handleDocketDisplayPage();
-
-    // If the page offers the ability to download a zip file, intercept navigation
-    // to the post-submit page.
-    content_delegate.handleZipFilePageView();
-
-    // If this is a document's menu of attachments (subdocuments), upload it to
-    // RECAP.
-    content_delegate.handleAttachmentMenuPage();
-
-    // If this page offers a single document, ask RECAP whether it has the document.
-    content_delegate.handleSingleDocumentPageCheck();
-
-    // If this page offers a single document, intercept navigation to the document
-    // view page.  The "View Document" button calls the goDLS() function, which
-    // creates a <form> element and calls submit() on it, so we hook into submit().
-    content_delegate.handleSingleDocumentPageView();
-
-    // If this is a Clams Register, we upload it to RECAP
-    content_delegate.handleClaimsPageView();
-
-    // Check every link in the document to see if there is a free RECAP document
-    // available. If there is, put a link with a RECAP icon.
-    content_delegate.attachRecapLinkToEligibleDocs();
-  } else {
-    console.info(`RECAP: Taking no actions because not logged in: ${url}`);
+// Callback function to execute when mutations in the input are observed
+function handleCaseIdChange(mutationRecords){
+  let target = mutationRecords[0].target
+  if (target.value != 0){
+    pacer_case_id = target.value
+    url = PACER.formatDocketQueryUrl(url, pacer_case_id)
+    getTabIdForContentScript().then(msg => {
+      saveCaseIdinTabStorage(msg, pacer_case_id)
+      addRecapInformation(msg)
+    });
   }
+}
+
+// Query relevant inputs in the page 
+let caseNumberInput = document.getElementById('case_number_text_area_0')
+let allCaseInput = document.getElementById('all_case_ids')
+
+if (allCaseInput){
+  // create a mutation observer to watch for changes being made to 
+  // the value attribute in the input with the id "all_case_id" 
+  const observer = new MutationObserver(mutationRecords => handleCaseIdChange(mutationRecords));
+  observer.observe(allCaseInput, {
+    attributes: true,
+    attributeFilter: [ "value"],
+  });
+}
+
+if (caseNumberInput){
+  // Add listener to the search bar
+  caseNumberInput.addEventListener('input', ()=>{
+    let banners = document.querySelectorAll('.recap-banner')
+    // Remove all HTML elements that the extension inserted 
+    banners.forEach(banner => {
+      banner.remove();
+    });
+  })
+}
+
+// if the content script didn't find the case Id,
+// check the page for the value in the input with the id 'all_case_ids'.
+if (!pacer_case_id){
+  let inputValue = !!allCaseInput && allCaseInput.value
+  if (!!inputValue){
+    pacer_case_id = inputValue
+    url = PACER.formatDocketQueryUrl(url, pacer_case_id)
+  }
+}
+
+// Get the tabId from the background worker to save the pacer_case_id 
+// in chrome local storage and add recap information to the page.
+getTabIdForContentScript().then(msg => {
+  if (pacer_case_id){
+    saveCaseIdinTabStorage(msg, pacer_case_id)
+  }
+  addRecapInformation(msg)
 });

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -87,6 +87,13 @@ let PACER = {
     return !!url.match(/\/(DktRpt|HistDocQry)\.pl\?\d+$/);
   },
 
+  // Returns the URL with the case id as a query parameter. This function makes
+  // sure every URL related to the Docket report has the same format
+  formatDocketQueryUrl: function(url, case_id){
+    return /[?&]/.test(url)  && /DktRpt.pl/.test(url)? url : `${url}?${case_id}`
+  },
+
+
   // Returns true if the given URL is for a docket display page (i.e. the page
   // after submitting the "Docket Sheet" query page).
   isDocketDisplayUrl: function (url) {

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -90,6 +90,22 @@ let PACER = {
   // Returns the URL with the case id as a query parameter. This function makes
   // sure every URL related to the Docket report has the same format
   formatDocketQueryUrl: function(url, case_id){
+    // The ContentDelegate class expects a URL like the following:
+    //
+    //    https://ecf.dcd.uscourts.gov/cgi-bin/DktRpt.pl?178502
+    //
+    // The case id is found after the start of the query string (after the '?') in 
+    // the previous URL, but the URL for the docket report accessed through the reports
+    // menu doesn’t have a query string so one example of that URL is:
+    //
+    //   https://ecf.dcd.uscourts.gov/cgi-bin/DktRpt.pl
+    // 
+    // This function checks if the URL has a query string and is related to the docket 
+    // report. if the URL has the same format as the first example, the function will return
+    // the same URL but, for those URL like the last example, it will append the query string 
+    // separator and the case id to make sure every URL has the format expected by the  
+    // ContentDelegate class
+
     return /[?&]/.test(url)  && /DktRpt.pl/.test(url)? url : `${url}?${case_id}`
   },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -173,6 +173,17 @@ const updateTabStorage = async object => {
   saveItemToStorage({ [tabId]: { ...store, ...updatedVars } });
 };
 
+// Save case_id in the chrome local storage
+const saveCaseIdinTabStorage = async (object, case_id) => {
+  const { tabId } = object;
+  const payload = {
+    caseId: case_id,
+  };
+  await updateTabStorage({
+    [tabId]: payload
+  })
+}
+
 // Default settings for any jquery $.ajax call.
 $.ajaxSetup({
   // The dataType parameter is a security measure requested by Opera code
@@ -220,7 +231,6 @@ function debug(level, varargs) {
 
 // inject a "follow this case on RECAP" button
 const recapAlertButton = (court, pacerCaseId, isActive) => {
-
   const anchor = document.createElement('a');
   anchor.setAttribute('id', 'recap-alert-button');
   anchor.setAttribute('role', 'button');


### PR DESCRIPTION
Fix [239](https://github.com/freelawproject/recap/issues/249)

PR addresses issues related to the docket report when it's accessed using the 'Reports' option in CM/ECF 1.6 and 1.7

Currently, the extension is not able to identify the page because the pacer_case_id is not part of the URL when the report loads.  The **case_id** is stored as the value of a hidden input with the id '**all_case_ids**' and changes when the user interacts with a text input used as a search bar for cases. 

The extension doesn't have the logic to listen to the changes being made to this value, so even when the **case_id** is inserted after the user specified a **case number**, the extension won't show the notice saying whether we have that docket or upload it. 

This PR adds a **listener** to the text input used as a search bar and a [Mutation observer](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) to the hidden input that stores the **case_id**. Both of these interfaces will provide the ability to watch for changes being made to the [DOM](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model) so the extension can keep track of the interactions of the user and the changes in the **case_id** to respond accordingly.

This PR also fixes the tests in the **ContentDelegateSpec.js** file by mocking a couple of ajax calls using [jasmine-ajax](https://github.com/jasmine/jasmine-ajax), adding fake functions to replace the `getElementById` and `querySelector` methods and removing the function that was deleting the chrome object in the global context.
