### PR TITLE
fix(recap popup): Remove recap popup and update anchors href

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Features:
  - None yet
 
 Changes:
- - None yet
+ - Remove option to "Confirm before opening RECAP documents" ([#216](https://github.com/freelawproject/recap/issues/216))
 
 Fixes: 
  - None yet

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -1291,21 +1291,6 @@ describe('The ContentDelegate class', function () {
         expect(recap_inline.length).toBe(1);
         recap_inline[0].remove();
       });
-
-      it('attaches a working click handler', function () {
-        spyOn(cd, 'handleRecapLinkClick');
-        spyOn(cd.recap, 'getAvailabilityForDocuments')
-          .and.callFake(function (pc, pci, callback) {
-            callback({
-              results:
-                [{ pacer_doc_id: 1234, filepath_local: 'download/1234' }],
-            });
-          });
-        cd.attachRecapLinkToEligibleDocs();
-        $(links[0]).next().click();
-        expect(cd.handleRecapLinkClick).toHaveBeenCalled();
-        document.querySelectorAll('.recap-inline')[0].remove();
-      });
     });
   });
 });

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -1159,67 +1159,6 @@ describe('The ContentDelegate class', function () {
 
   // TODO: Figure out where the functionality of
   //  'addMouseoverToConvertibleLinks' went, and add tests for that.
-
-  describe('handleRecapLinkClick', function () {
-    const cd = docketDisplayContentDelegate;
-    const linkUrl = singleDocUrl;
-
-    afterEach(function () {
-      delete window.chrome;
-    });
-
-    describe('when the popup option is not set', function () {
-      beforeEach(function () {
-        window.chrome = {
-          storage: {
-            local: {
-              get: jasmine.createSpy().and.callFake(function (
-                _, cb) { cb({ options: {} }); })
-            }
-          }
-        };
-      });
-
-      it('redirects to the link url immediately', function () {
-        const window_obj = {};
-        cd.handleRecapLinkClick(window_obj, linkUrl);
-        expect(window_obj.location).toBe(linkUrl);
-      });
-    });
-
-    describe('when the popup option is set', function () {
-      beforeEach(function () {
-        window.chrome = {
-          storage: {
-            local: {
-              get: jasmine.createSpy().and.callFake(function (
-                _, cb) { cb({ options: { recap_link_popups: true } }); }),
-              set: jasmine.createSpy('set').and.callFake(function () { })
-            }
-          }
-        };
-      });
-
-      it('attaches the RECAP popup', function () {
-        cd.handleRecapLinkClick({}, linkUrl);
-        recap_shade = document.querySelectorAll('#recap-shade')
-        recap_popup = document.querySelectorAll('.recap-popup')
-        expect(recap_shade.length).not.toBe(0);
-        expect(recap_popup.length).not.toBe(0);
-
-        let foundLink = false;
-        $('.recap-popup a').each(function (i, link) {
-          if (link.href === linkUrl) {
-            foundLink = true;
-          }
-        });
-        expect(foundLink).toBe(true);
-        recap_shade[0].remove();
-        recap_popup[0].remove();
-      });
-    });
-  });
-
   describe('attachRecapLinkToEligibleDocs', function () {
     const fake_urls = [
       'http://foo.fake/bar/0',

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -622,42 +622,6 @@ ContentDelegate.prototype.handleSingleDocumentPageView = function () {
     'message', this.onDocumentViewSubmit.bind(this), false);
 };
 
-// Pop up a dialog offering the link to the free cached copy of the document,
-// or just go directly to the free document if popups are turned off.
-ContentDelegate.prototype.handleRecapLinkClick = function (window_obj, url) {
-  chrome.storage.local.get('options', function (items) {
-    if (!items.options.recap_link_popups) {
-      window_obj.location = url;
-      return;
-    }
-    $('<div id="recap-shade"/>').appendTo($('body'));
-    $('<div class="recap-popup"/>').append(
-      $('<a/>', {
-        'class': 'recap-close-link',
-        href: '#',
-        onclick: 'var d = document; d.body.removeChild(this.parentNode); ' +
-          'd.body.removeChild(d.getElementById("recap-shade")); return false'
-      }).append(
-        '\u00d7'
-      )
-    ).append(
-      $('<a/>', {
-        href: url,
-        onclick: 'var d = document; d.body.removeChild(this.parentNode); ' +
-          'd.body.removeChild(d.getElementById("recap-shade"))'
-      }).append(
-        ' Get this document for free from RECAP.'
-      )
-    ).append(
-      $('<br><br><small>Note that archived documents may be out of date. ' +
-        'RECAP is not affiliated with the U.S. Courts. The documents ' +
-        'it makes available are voluntarily uploaded by PACER users. ' +
-        'RECAP cannot guarantee the authenticity of documents because the ' +
-        'courts provide no effective document authentication system.</small>')
-    ).appendTo($('body'));
-  });
-  return false;
-};
 
 // Check every link in the document to see if there is a free RECAP document
 // available. If there is, put a link with a RECAP icon.
@@ -684,13 +648,12 @@ ContentDelegate.prototype.attachRecapLinkToEligibleDocs = function () {
         if (!result) {
           continue;
         }
-        let href = `https://www.courtlistener.com/${result.filepath_local}`;
+        let href = `https://storage.courtlistener.com/${result.filepath_local}`;
         let recap_link = $('<a/>', {
           'class': 'recap-inline',
           'title': 'Available for free from the RECAP Archive.',
           'href': href
         });
-        recap_link.click($.proxy(this.handleRecapLinkClick, this, window, href));
         recap_link.append($('<img/>').attr({
           src: chrome.extension.getURL('assets/images/icon-16.png')
         }));

--- a/src/options.html
+++ b/src/options.html
@@ -106,18 +106,6 @@
             </div>
           </fieldset>
           
-          <fieldset id="recap_email" class="hidden">
-            <legend>@recap.email</legend>
-            <div>
-              <p>As a filing user, you can add a special email address to your account that will automatically add all of your cases to the RECAP Archive.</p>
-              <a href="https://www.courtlistener.com/help/recap/email/"
-                target="_blank"
-                rel="noopener">
-                Learn More
-              </a>
-            </div>
-          </fieldset>
-
           <!-- TBD: Optimize PACER.
                 See https://github.com/freelawproject/recap/issues/207 -->
           <fieldset class="hidden"><legend>Optimize PACER</legend>

--- a/src/options.html
+++ b/src/options.html
@@ -105,7 +105,6 @@
               </div>
             </div>
           </fieldset>
-          
           <!-- TBD: Optimize PACER.
                 See https://github.com/freelawproject/recap/issues/207 -->
           <fieldset class="hidden"><legend>Optimize PACER</legend>

--- a/src/options.html
+++ b/src/options.html
@@ -83,15 +83,6 @@
                     Notify me when RECAP uploads a file to the Archive
               </div>
             </label>
-            <label for="recap_link_popups"
-                title="Pop up a dialog whenever you click a RECAP link to a free document">
-              <div class="item">
-                    <span class="icon">
-                      <input id="recap_link_popups" type="checkbox">
-                    </span>
-                    Confirm before opening free documents
-              </div>
-            </label>
           </fieldset>
 
           <fieldset><legend>PDF Files</legend>
@@ -112,6 +103,18 @@
                 <input class="form-check-input position-relative" type="radio" id="lawyer_style_filenames" name="filename_style" value="lawyer_style_filenames">
                 <label class="form-check-label" for="lawyer_style_filenames">Lawyer style</label>
               </div>
+            </div>
+          </fieldset>
+          
+          <fieldset id="recap_email" class="hidden">
+            <legend>@recap.email</legend>
+            <div>
+              <p>As a filing user, you can add a special email address to your account that will automatically add all of your cases to the RECAP Archive.</p>
+              <a href="https://www.courtlistener.com/help/recap/email/"
+                target="_blank"
+                rel="noopener">
+                Learn More
+              </a>
             </div>
           </fieldset>
 


### PR DESCRIPTION
This PR solves multiple issues related to the links inserted by the RECAP extension:

- Avoid creating links that redirect to storage.courtlistener.com:
  The links inserted by the extension go to [www.courtlistener.com](http://www.courtlistener.com/), which redirects to `storage.courtlistener.com`. This PR will change the links used in the href of the anchor tags to avoid redirection.  
- Remove the option to use a popup before opening RECAP documents
  The current implementation of the extension has a check box on the options page that says, "Confirm before opening RECAP documents". If it's checked( which it is by default) it pops up a modal whenever you click an [R] icon to download a document. This PR fixes [#216](https://github.com/freelawproject/recap/issues/216) by removing all the logic related to this popup and updating the test in the ContentDelegateSpec file.