### PR TITLE
fix(links from appellate): Makes isDocketQueryUrl more generic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Changes:
 
 Fixes: 
  - Tighten security by verifying the sender's identity in communication between Window objects. This prevents a theoretical attack vector that might, with a lot of care and effort, have been able to send bad data to the RECAP Archive. ([#236](https://github.com/freelawproject/recap/issues/236))
+ - Fix logic to handle links from appellate PACER to district PACER ([#222](https://github.com/freelawproject/recap/issues/222))
 
 For developers:
  - Nothing yet

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -334,6 +334,7 @@ describe('The ContentDelegate class', function () {
 
       describe('when the history state is already set', function () {
         beforeEach(function () {
+          document.getElementById = jasmine.createSpy('getElementById').and.callFake( id => document.querySelectorAll(`#${id}`)[0])
           history.replaceState({ uploaded: true }, '');
         });
 
@@ -362,6 +363,7 @@ describe('The ContentDelegate class', function () {
           input2.id = "input2";
           document.body.appendChild(input);
           document.body.appendChild(input2);
+          document.getElementById = jasmine.createSpy('getElementById').and.callFake( id => document.querySelectorAll(`#${id}`)[0])
         });
 
         afterEach(function () {

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -7,6 +7,10 @@ describe('The PACER module', function() {
   const singleDocUrl = 'https://ecf.canb.uscourts.gov/doc1/034031424909';
   const docketQueryUrl = ('https://ecf.canb.uscourts.gov/cgi-bin/' +
     'HistDocQry.pl?531316');
+  const docketQueryUrlFromAppellate = ('https://ecf.canb.uscourts.gov/cgi-bin/' +
+    'DktRpt.pl?caseNumber=2:16-cv-01129-RFB-DJA');
+  const docketQueryUrlWithMultiParameter = ('https://ecf.canb.uscourts.gov/cgi-bin/' +
+    'DktRpt.pl?caseNumber=1:17-cv-10577&caseId=0'); 
   const appellateDocumentUrl = 'https://ecf.ca2.uscourts.gov/docs1/00205695758';
 
   function InputContainer() {
@@ -84,8 +88,20 @@ describe('The PACER module', function() {
   });
 
   describe('isDocketQueryUrl', function() {
-    it('matches a valid docket query URL', function() {
+    it('matches a docket query URL with digits in the query string', function() {
       expect(PACER.isDocketQueryUrl(docketQueryUrl)).toBe(true);
+    });
+
+    it('matches a docket query URL with one parameter in the query string', function(){
+      expect(PACER.isDocketQueryUrl(docketQueryUrlFromAppellate)).toBe(true);
+    });
+
+    it ('matches a docket query URL with multiple parameters in the query string', function(){
+      expect(PACER.isDocketQueryUrl(docketQueryUrlWithMultiParameter)).toBe(true);
+    });
+
+    it ('returns false for a docket query URL that does not have querystring', function(){
+      expect(PACER.isDocketQueryUrl(docketReportURL)).toBe(false);
     });
 
     it('returns false for a document URL', function() {

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -84,10 +84,18 @@ let PACER = {
       return match[0].slice(1);
     }
   },
+  
   // Returns true if the URL is for docket query page.
   isDocketQueryUrl: function (url) {
-    // The part after the "?" is all digits.
-    return !!url.match(/\/(DktRpt|HistDocQry)\.pl\?\d+$/);
+    // This regex expression will match URLs that has a query string with only
+    // digits or has a parameter named caseNumber followed by word characters, 
+    // hyphens or colons. This function will return true for the following URLs:
+    // 
+    //  https://ecf.mied.uscourts.gov/cgi-bin/DktRpt.pl?365816
+    //  
+    //  https://ecf.moed.uscourts.gov/cgi-bin/DktRpt.pl?caseNumber=4:19-cr-00820-SRC-1
+    //
+    return !!url.match(/\/(DktRpt|HistDocQry)\.pl\?(\d+|caseNumber=[\w:-]+)$/);
   },
 
   // Returns true if the URL is for the manage account page.

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -87,16 +87,23 @@ let PACER = {
   
   // Returns true if the URL is for docket query page.
   isDocketQueryUrl: function (url) {
-    // This regex expression will match URLs that has a query string with only
-    // digits or has one or multiple parameters separated by the ampersand ("&").
+    // There are two pages that use the DktRpt.pl url that we want to match:
+    //  - The docket query page: /DktRpt.pl?115206
+    //  - The docket report page: /DktRpt.pl?caseNumber=1:17-cv-10577&caseId=0
+    // 
+    // And one page that uses DktRpt.pl that we don't want to match:
+    //  - The docket page itself: /DktRpt.pl?591030040473392-L_1_0-1
+    // 
+    // Thus, this regex matches URLs that have a query string with only digits
+    // or that has one or multiple parameters separated by the ampersand ("&").
     //
     // This function will return true for the following URLs:
-    // 
-    //  https://ecf.mied.uscourts.gov/cgi-bin/DktRpt.pl?365816
-    //  
-    //  https://ecf.moed.uscourts.gov/cgi-bin/DktRpt.pl?caseNumber=4:19-cr-00820-SRC-1
+    //  - DktRpt.pl?365816
+    //  - DktRpt.pl?caseNumber=4:19-cr-00820-SRC-1
+    //  - DktRpt.pl?caseNumber=1:17-cv-10577&caseId=0
     //
-    //  https://ecf.mad.uscourts.gov/cgi-bin/DktRpt.pl?caseNumber=1:17-cv-10577&caseId=0
+    // But false for:
+    //  - /DktRpt.pl?591030040473392-L_1_0-1
     //
     return !!url.match(/\/(DktRpt|HistDocQry)\.pl\?(\d+|(&?[\w]+=[^&=\n]+)+)$/);
   },

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -88,14 +88,17 @@ let PACER = {
   // Returns true if the URL is for docket query page.
   isDocketQueryUrl: function (url) {
     // This regex expression will match URLs that has a query string with only
-    // digits or has a parameter named caseNumber followed by word characters, 
-    // hyphens or colons. This function will return true for the following URLs:
+    // digits or has one or multiple parameters separated by the ampersand ("&").
+    //
+    // This function will return true for the following URLs:
     // 
     //  https://ecf.mied.uscourts.gov/cgi-bin/DktRpt.pl?365816
     //  
     //  https://ecf.moed.uscourts.gov/cgi-bin/DktRpt.pl?caseNumber=4:19-cr-00820-SRC-1
     //
-    return !!url.match(/\/(DktRpt|HistDocQry)\.pl\?(\d+|caseNumber=[\w:-]+)$/);
+    //  https://ecf.mad.uscourts.gov/cgi-bin/DktRpt.pl?caseNumber=1:17-cv-10577&caseId=0
+    //
+    return !!url.match(/\/(DktRpt|HistDocQry)\.pl\?(\d+|(&?[\w]+=[^&=\n]+)+)$/);
   },
 
   // Returns true if the URL is for the manage account page.


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/recap/issues/222

The current implementation of the isDocketQueryUrl function only matches URLs that have a query string with only digits. That was fine, but the link from the appellate pacer to the original case has a different query string that includes the caseNumber parameter, so doesn't match properly in that case. 

The new regex expression will match both cases. Here's a gif showing that the extension will be able to insert banners in the `DktRpt.pl` after following the link in the appellate pacer.

![recap-originating-case-number](https://user-images.githubusercontent.com/55959657/205193478-351dc3e7-2618-4638-835b-720e05974e99.gif)
