### PR TITLE
feat(attachment page): Add support for attachment page from Appellate PACER

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -13,3 +13,6 @@ d891dad8127683ab8263d61b1bee71db0d08a4ef
 
 # Change code styling in ContentDelegateSpec.js
 16cf83c12d9bb3edc350abf7002abca312211fe2
+
+# Change code styling in action_button.js
+d36f8b36a38873b775efd7edd30bbed4b3ceaa66

--- a/spec/AppellateSpec.js
+++ b/spec/AppellateSpec.js
@@ -11,6 +11,8 @@ describe('The Appellate module', function () {
     'https://ecf.ca9.uscourts.gov/docs1/009031927529',
     'https://ecf.ca9.uscourts.gov/docs1/009031956734',
   ];
+  const searchParamsWithCaseId = new URLSearchParams('servlet=DocketReportFilter.jsp&caseId=318547');
+  const searchParamsWithoutCaseId = new URLSearchParams('servlet=DocketReportFilter.jsp');
 
   function clearBody() {
     document.body.innerHTML = '';
@@ -52,9 +54,9 @@ describe('The Appellate module', function () {
     });
   });
 
-  describe('getCaseIdFromInputs', function () {
+  describe('getCaseId', function () {
 
-    describe('for pages with matching format', function(){
+    describe('for pages with inputs', function(){
 
       beforeEach(function () {
         clearBody();
@@ -67,8 +69,8 @@ describe('The Appellate module', function () {
         });
       });
 
-      it('returns the caseId value', function () {
-        expect(APPELLATE.getCaseIdFromInputs()).toBe('318457');
+      it('returns the caseId value', async function () {
+        expect(await APPELLATE.getCaseId('1234', searchParamsWithoutCaseId)).toBe('318457');
       });
 
     })
@@ -76,10 +78,22 @@ describe('The Appellate module', function () {
     describe('for pages with non-matching format', function () {
       beforeEach(function () {
         clearBody();
+        window.chrome = {
+          storage: {
+            local: {
+              get: jasmine.createSpy().and.callFake(function (_, cb) {
+                cb({
+                  [1234]: { },
+                  options: { recap_enabled: true },
+                });
+              })
+            },
+          },
+        };
       });
 
-      it('returns undefined', function () {
-        expect(APPELLATE.getCaseIdFromInputs()).toBeUndefined();
+      it('returns undefined', async function () {
+        expect(await APPELLATE.getCaseId('1234', searchParamsWithoutCaseId)).toBeUndefined();
       });
     });
   });

--- a/spec/AppellateSpec.js
+++ b/spec/AppellateSpec.js
@@ -17,10 +17,101 @@ describe('The Appellate module', function () {
   }
 
   describe('getQueryParameters', function () {
-
     it('returns URLSearchParams interface', function () {
       expect(APPELLATE.getQueryParameters(nonQueryStringUrl)).toBeInstanceOf(URLSearchParams);
       expect(APPELLATE.getQueryParameters(caseSummaryPage)).toBeInstanceOf(URLSearchParams);
+    });
+  });
+
+  describe('getServletFromInputs', function () {
+    describe('for pages with matching format', function () {
+      beforeEach(function () {
+        clearBody();
+        let input = document.createElement('input');
+        input.setAttribute('name', 'servlet');
+        input.setAttribute('value', 'CaseSelectionTable.jsp');
+        document.body.appendChild(input);
+        document.querySelector = jasmine.createSpy('querySelector').and.callFake((query) => {
+          return document.querySelectorAll(query).length ? document.querySelectorAll(query)[0] : null;
+        });
+      });
+
+      it('returns the servlet parameter', function () {
+        expect(APPELLATE.getServletFromInputs()).toBe('CaseSelectionTable.jsp');
+      });
+    });
+
+    describe('for pages with non-matching format', function () {
+      beforeEach(function () {
+        clearBody();
+      });
+
+      it('returns undefined', function () {
+        expect(APPELLATE.getServletFromInputs()).toBeUndefined();
+      });
+    });
+  });
+
+  describe('getCaseIdFromInputs', function () {
+
+    describe('for pages with matching format', function(){
+
+      beforeEach(function () {
+        clearBody();
+        let input = document.createElement('input');
+        input.setAttribute('name', 'caseId');
+        input.setAttribute('value', '318457');
+        document.body.appendChild(input);
+        document.querySelector = jasmine.createSpy('querySelector').and.callFake((query) => {
+          return document.querySelectorAll(query).length ? document.querySelectorAll(query)[0] : null;
+        });
+      });
+
+      it('returns the caseId value', function () {
+        expect(APPELLATE.getCaseIdFromInputs()).toBe('318457');
+      });
+
+    })
+
+    describe('for pages with non-matching format', function () {
+      beforeEach(function () {
+        clearBody();
+      });
+
+      it('returns undefined', function () {
+        expect(APPELLATE.getCaseIdFromInputs()).toBeUndefined();
+      });
+    });
+  });
+
+  describe('isAttachmentPage', function () {
+    describe('for pages with matching format', function () {
+      beforeEach(function () {
+        clearBody();
+        let form = document.createElement('form');
+        form.setAttribute('name', 'dktEntry');
+        document.body.appendChild(form);
+        document.querySelector = jasmine.createSpy('querySelector').and.callFake((query) => {
+          return document.querySelectorAll(query).length ? document.querySelectorAll(query)[0] : null;
+        });
+      });
+
+      it('returns true', function () {
+        expect(APPELLATE.isAttachmentPage()).toBe(true);
+      });
+    });
+
+    describe('for pages with non-matching format', function () {
+      beforeEach(function () {
+        clearBody();
+        document.querySelector = jasmine.createSpy('querySelector').and.callFake((query) => {
+          return document.querySelectorAll(query).length ? document.querySelectorAll(query)[0] : null;
+        });
+      });
+
+      it('returns false', function () {
+        expect(APPELLATE.isAttachmentPage()).toBe(false);
+      });
     });
   });
 
@@ -189,6 +280,18 @@ describe('The Appellate module', function () {
       it('returns the caseId', function () {
         expect(APPELLATE.getCaseIdFromCaseSelection()).toBe('318547');
       });
+    });
+  });
+
+  describe('createDummyIframe', function () {
+    beforeEach(function () {
+      clearBody();
+    });
+
+    it('inserts iframe in document body', function () {
+      APPELLATE.createDummyIframe('dummy_frame');
+      let iframe = document.querySelectorAll("iframe[name='dummy_frame']");
+      expect(iframe.length).toBe(1);
     });
   });
 });

--- a/spec/AppellateSpec.js
+++ b/spec/AppellateSpec.js
@@ -141,8 +141,8 @@ describe('The Appellate module', function () {
 
   describe('findDocLinksFromAnchors', function () {
     it('returns empty array for empty input', function () {
-      let [doc_id, ] = APPELLATE.findDocLinksFromAnchors([]);
-      expect(doc_id.length).toBe(0);
+      let {links, } = APPELLATE.findDocLinksFromAnchors([]);
+      expect(links.length).toBe(0);
     });
 
     describe('for documents with links', function () {
@@ -166,8 +166,8 @@ describe('The Appellate module', function () {
 
         it('returns empty array', function () {
           let anchors = document.querySelectorAll('#no_links > a');
-          let [doc_id,_] = APPELLATE.findDocLinksFromAnchors(anchors);
-          expect(doc_id.length).toBe(0);
+          let { links, _ } = APPELLATE.findDocLinksFromAnchors(anchors);
+          expect(links.length).toBe(0);
         });
       });
 
@@ -191,9 +191,9 @@ describe('The Appellate module', function () {
 
         it('returns array with doc_ids', function () {
           let anchors = document.querySelectorAll('#links > a');
-          let [doc_id, _] = APPELLATE.findDocLinksFromAnchors(anchors);
-          expect(doc_id.length).toBe(2);
-          expect(doc_id).toEqual(['009031927529', '009031956734']);
+          let { links, _ } = APPELLATE.findDocLinksFromAnchors(anchors);
+          expect(links.length).toBe(2);
+          expect(links).toEqual(['009031927529', '009031956734']);
         });
       });
     });

--- a/spec/AppellateSpec.js
+++ b/spec/AppellateSpec.js
@@ -141,7 +141,7 @@ describe('The Appellate module', function () {
 
   describe('findDocLinksFromAnchors', function () {
     it('returns empty array for empty input', function () {
-      let doc_id = APPELLATE.findDocLinksFromAnchors([]);
+      let [doc_id, ] = APPELLATE.findDocLinksFromAnchors([]);
       expect(doc_id.length).toBe(0);
     });
 
@@ -166,7 +166,7 @@ describe('The Appellate module', function () {
 
         it('returns empty array', function () {
           let anchors = document.querySelectorAll('#no_links > a');
-          let doc_id = APPELLATE.findDocLinksFromAnchors(anchors);
+          let [doc_id,_] = APPELLATE.findDocLinksFromAnchors(anchors);
           expect(doc_id.length).toBe(0);
         });
       });
@@ -191,7 +191,7 @@ describe('The Appellate module', function () {
 
         it('returns array with doc_ids', function () {
           let anchors = document.querySelectorAll('#links > a');
-          let doc_id = APPELLATE.findDocLinksFromAnchors(anchors);
+          let [doc_id, _] = APPELLATE.findDocLinksFromAnchors(anchors);
           expect(doc_id.length).toBe(2);
           expect(doc_id).toEqual(['009031927529', '009031956734']);
         });
@@ -297,15 +297,4 @@ describe('The Appellate module', function () {
     });
   });
 
-  describe('createDummyIframe', function () {
-    beforeEach(function () {
-      clearBody();
-    });
-
-    it('inserts iframe in document body', function () {
-      APPELLATE.createDummyIframe('dummy_frame');
-      let iframe = document.querySelectorAll("iframe[name='dummy_frame']");
-      expect(iframe.length).toBe(1);
-    });
-  });
 });

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -297,8 +297,6 @@ describe('The ContentDelegate class', function () {
 
   describe('handleDocketDisplayPage', function () {
     describe('option disabled', function () {
-      let table;
-
       beforeEach(function () {
         clearDocumentBody();
         table = document.createElement('table');
@@ -325,14 +323,10 @@ describe('The ContentDelegate class', function () {
         };
         document.querySelector = jasmine
           .createSpy('querySelector')
-          .and.callFake((id) => (id != 'tbody' ? null : tbody));
+          .and.callFake((id) => (document.querySelectorAll(id).length ? document.querySelectorAll(id)[0] : null));
         document.getElementById = jasmine
           .createSpy('getElementById')
           .and.callFake((id) => document.querySelectorAll(`#${id}`)[0]);
-      });
-
-      afterEach(function () {
-        table.remove();
       });
 
       it('has no effect when recap_enabled option is false', function () {
@@ -344,16 +338,7 @@ describe('The ContentDelegate class', function () {
     });
 
     describe('option enabled', function () {
-      let table;
-
       beforeEach(function () {
-        clearDocumentBody();
-        table = document.createElement('table');
-        const tbody = document.createElement('tbody');
-        const tr = document.createElement('tr');
-        tbody.appendChild(tr);
-        table.appendChild(tbody);
-        document.body.appendChild(table);
         window.chrome = {
           extension: { getURL: jasmine.createSpy('gerURL') },
           storage: {
@@ -370,35 +355,47 @@ describe('The ContentDelegate class', function () {
         };
         document.querySelector = jasmine
           .createSpy('querySelector')
-          .and.callFake((id) => (id != 'tbody' ? null : tbody));
+          .and.callFake((id) => (document.querySelectorAll(id).length ? document.querySelectorAll(id)[0] : null));
         document.getElementById = jasmine
           .createSpy('getElementById')
           .and.callFake((id) => document.querySelectorAll(`#${id}`)[0]);
       });
 
-      afterEach(function () {
-        table.remove();
-      });
+      describe('has no effect', function () {
+        beforeEach(function () {
+          clearDocumentBody();
+          table = document.createElement('table');
+          const tbody = document.createElement('tbody');
+          const tr = document.createElement('tr');
+          tbody.appendChild(tr);
+          table.appendChild(tbody);
+          document.body.appendChild(table);
+        });
 
-      it('has no effect when not on a docket display url', function () {
-        const cd = nonsenseUrlContentDelegate;
-        spyOn(cd.recap, 'uploadDocket');
-        cd.handleDocketDisplayPage();
-        expect(cd.recap.uploadDocket).not.toHaveBeenCalled();
-      });
+        it('when not on a docket display url', function () {
+          const cd = nonsenseUrlContentDelegate;
+          spyOn(cd.recap, 'uploadDocket');
+          cd.handleDocketDisplayPage();
+          expect(cd.recap.uploadDocket).not.toHaveBeenCalled();
+        });
 
-      it('has no effect when there is no casenum', function () {
-        const cd = new ContentDelegate(tabId, docketDisplayUrl, undefined, 'canb', undefined, undefined, []);
-        spyOn(cd.recap, 'uploadDocket');
-        cd.handleDocketDisplayPage();
-        expect(cd.recap.uploadDocket).not.toHaveBeenCalled();
+        it('when there is no casenum', function () {
+          const cd = new ContentDelegate(tabId, docketDisplayUrl, undefined, 'canb', undefined, undefined, []);
+          spyOn(cd.recap, 'uploadDocket');
+          cd.handleDocketDisplayPage();
+          expect(cd.recap.uploadDocket).not.toHaveBeenCalled();
+        });
       });
 
       describe('when the history state is already set', function () {
         beforeEach(function () {
-          document.getElementById = jasmine
-            .createSpy('getElementById')
-            .and.callFake((id) => document.querySelectorAll(`#${id}`)[0]);
+          clearDocumentBody();
+          table = document.createElement('table');
+          const tbody = document.createElement('tbody');
+          const tr = document.createElement('tr');
+          tbody.appendChild(tr);
+          table.appendChild(tbody);
+          document.body.appendChild(table);
           history.replaceState({ uploaded: true }, '');
         });
 
@@ -414,11 +411,16 @@ describe('The ContentDelegate class', function () {
         });
       });
 
-      // interstitial check is multiple inputs with name 'date_from' and type 'radio'
       describe('when the docket page is an interstitial page', function () {
         let input, input2;
 
         beforeEach(function () {
+          clearDocumentBody();
+          table = document.createElement('table');
+          const tbody = document.createElement('tbody');
+          const tr = document.createElement('tr');
+          tbody.appendChild(tr);
+          table.appendChild(tbody);
           input = document.createElement('input');
           input.id = 'input1';
           input.name = 'date_from';
@@ -427,14 +429,7 @@ describe('The ContentDelegate class', function () {
           input2.id = 'input2';
           document.body.appendChild(input);
           document.body.appendChild(input2);
-          document.getElementById = jasmine
-            .createSpy('getElementById')
-            .and.callFake((id) => document.querySelectorAll(`#${id}`)[0]);
-        });
-
-        afterEach(function () {
-          input.remove();
-          input2.remove();
+          document.body.appendChild(table);
         });
 
         it('does not call uploadDocket', async function () {
@@ -454,12 +449,6 @@ describe('The ContentDelegate class', function () {
           tbody.appendChild(tr);
           table.appendChild(tbody);
           document.body.appendChild(table);
-          document.querySelector = jasmine
-            .createSpy('querySelector')
-            .and.callFake((id) => (id != 'tbody' ? null : tbody));
-          document.getElementById = jasmine
-            .createSpy('getElementById')
-            .and.callFake((id) => document.querySelectorAll(`#${id}`)[0]);
         });
 
         it('inserts a button linking the user to a create alert page on CL', async () => {
@@ -677,7 +666,9 @@ describe('The ContentDelegate class', function () {
 
         it('calls the upload method and responds to positive result', function () {
           const cd = singleDocContentDelegate;
-          const uploadFake = function (pc, pci, h, ut, callback) { callback(true); };
+          const uploadFake = function (pc, pci, h, ut, callback) {
+            callback(true);
+          };
           spyOn(cd.recap, 'uploadAttachmentMenu').and.callFake(uploadFake);
           spyOn(cd.notifier, 'showUpload');
           spyOn(history, 'replaceState');
@@ -690,7 +681,9 @@ describe('The ContentDelegate class', function () {
 
         it('calls the upload method and responds to negative result', function () {
           const cd = singleDocContentDelegate;
-          const uploadFake = function (pc, pci, h, ut, callback) { callback(false); };
+          const uploadFake = function (pc, pci, h, ut, callback) {
+            callback(false);
+          };
           spyOn(cd.recap, 'uploadAttachmentMenu').and.callFake(uploadFake);
           spyOn(cd.notifier, 'showUpload');
           spyOn(history, 'replaceState');

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -594,7 +594,7 @@ describe('The ContentDelegate class', function () {
 
         it('calls the upload method and responds to positive result', function () {
           const cd = singleDocContentDelegate;
-          const uploadFake = function (pc, pci, h, callback) { callback(true); };
+          const uploadFake = function (pc, pci, h, ut, callback) { callback(true); };
           spyOn(cd.recap, 'uploadAttachmentMenu').and.callFake(uploadFake);
           spyOn(cd.notifier, 'showUpload');
           spyOn(history, 'replaceState');
@@ -608,7 +608,7 @@ describe('The ContentDelegate class', function () {
 
         it('calls the upload method and responds to negative result', function () {
           const cd = singleDocContentDelegate;
-          const uploadFake = function (pc, pci, h, callback) { callback(false); };
+          const uploadFake = function (pc, pci, h, ut, callback) { callback(false); };
           spyOn(cd.recap, 'uploadAttachmentMenu').and.callFake(uploadFake);
           spyOn(cd.notifier, 'showUpload');
           spyOn(history, 'replaceState');

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -1080,6 +1080,10 @@ describe('The ContentDelegate class', function () {
         // });
       });
 
+      afterEach(function(){
+        window.getPacerCaseIdFromPacerDocId = jasmine.createSpy().and.callThrough()
+      })
+
       it('makes the back button redisplay the previous page', async function () {
         await cd.showPdfPage(documentElement, html);
         expect(window.onpopstate).toEqual(jasmine.any(Function));

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -612,4 +612,26 @@ describe('The PACER module', function() {
       });
     })
   })
+
+  describe('parseDoDocPostURL', function () {
+    it('gets the right values for an example doDoc string', function () {
+      let goDLSSampleString = "return doDocPostURL('009032024698','318547');";
+      expect(PACER.parseDoDocPostURL(goDLSSampleString)).toEqual({
+        doc_id: '009032024698',
+        case_id: '318547',
+      });
+    });
+
+    it('returns false for an invalid string', function () {
+      expect(PACER.parseGoDLSFunction('not a goDLS function call')).toBeNull();
+    });
+
+    it('returns false for a null input', function () {
+      expect(PACER.parseGoDLSFunction(null)).toBeNull();
+    });
+
+    it('returns false for an undefined input', function () {
+      expect(PACER.parseGoDLSFunction(undefined)).toBeNull();
+    });
+  });
 });

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -190,7 +190,7 @@ describe('The Recap export module', function () {
     });
 
     it('requests the correct URL', function () {
-      recap.uploadAttachmentMenu(court, filename, type, html);
+      recap.uploadAttachmentMenu(court, filename, type, html, 'ATTACHMENT_PAGE');
       expect(jasmine.Ajax.requests.mostRecent().url).toBe(
         'https://www.courtlistener.com/api/rest/v3/recap/');
     });
@@ -203,7 +203,7 @@ describe('The Recap export module', function () {
       expected.append('filepath_local', new Blob(
         [html], { type: type }), filename);
 
-      recap.uploadAttachmentMenu(court, pacer_case_id, html, function () { });
+      recap.uploadAttachmentMenu(court, pacer_case_id, html, 'ATTACHMENT_PAGE', function () { });
       const actualData = jasmine.Ajax.requests.mostRecent().data();
       expect(actualData).toEqual(jasmine.objectContaining(expected));
     });

--- a/src/action_button.js
+++ b/src/action_button.js
@@ -1,109 +1,109 @@
 // Handles the insertion of the "Create alert" option in the dropdown menu
 const addAlertButtonInRecapAction = (court, pacerCaseId) => {
-  let dropdownHeader = document.getElementById('action-button-dropdown-header')
-  if (!dropdownHeader){
+  let dropdownHeader = document.getElementById('action-button-dropdown-header');
+  if (!dropdownHeader) {
     return;
   }
-  let existingAlertButton = document.getElementById('create-alert-button')
+  let existingAlertButton = document.getElementById('create-alert-button');
   if (!existingAlertButton) {
-      let alertLi = document.createElement("li");
-      alertLi.setAttribute('id', 'create-alert-button')
-      let createAlert = document.createElement('a')
+    let alertLi = document.createElement('li');
+    alertLi.setAttribute('id', 'create-alert-button');
+    let createAlert = document.createElement('a');
 
-      const url = new URL('https://www.courtlistener.com/alert/docket/new/');
-      url.searchParams.append('pacer_case_id', pacerCaseId);
-      url.searchParams.append('court_id', court);
+    const url = new URL('https://www.courtlistener.com/alert/docket/new/');
+    url.searchParams.append('pacer_case_id', pacerCaseId);
+    url.searchParams.append('court_id', court);
 
-      createAlert.href = url.toString();
-      createAlert.innerHTML = 'Create alert'
-      createAlert.setAttribute('target', '_blank');
-      alertLi.appendChild(createAlert)
-      dropdownHeader.after(alertLi);
+    createAlert.href = url.toString();
+    createAlert.innerHTML = 'Create alert';
+    createAlert.setAttribute('target', '_blank');
+    alertLi.appendChild(createAlert);
+    dropdownHeader.after(alertLi);
   }
 };
 
 // Handles the insertion of the "Search this docket" option in the dropdown menu
 const addSearchDocketInRecapAction = (cl_id) => {
-  let viewDocketButton = document.getElementById('view-docket-button')
-  if (!viewDocketButton){
+  let viewDocketButton = document.getElementById('view-docket-button');
+  if (!viewDocketButton) {
     return;
   }
-  let existingSearchButton = document.getElementById('search-docket-button')
+  let existingSearchButton = document.getElementById('search-docket-button');
   if (!existingSearchButton) {
-    let docketLi = document.createElement('li')
-    docketLi.setAttribute('id', 'search-docket-button')
-    let searchDocket = document.createElement('a')
-    searchDocket.innerHTML = 'Search this Docket'
-    searchDocket.href = `https://www.courtlistener.com/?type=r&q=docket_id%3A${cl_id}`
+    let docketLi = document.createElement('li');
+    docketLi.setAttribute('id', 'search-docket-button');
+    let searchDocket = document.createElement('a');
+    searchDocket.innerHTML = 'Search this Docket';
+    searchDocket.href = `https://www.courtlistener.com/?type=r&q=docket_id%3A${cl_id}`;
     searchDocket.setAttribute('target', '_blank');
-    docketLi.appendChild(searchDocket)
-    viewDocketButton.before(docketLi)
+    docketLi.appendChild(searchDocket);
+    viewDocketButton.before(docketLi);
   }
-}
+};
 
 // creates the dropdown menu content
 const recapDropdownMenu = (court, pacerCaseId) => {
-    let dropdownWrapper = document.createElement('ul')
-    dropdownWrapper.classList.add('dropdown-menu')
+  let dropdownWrapper = document.createElement('ul');
+  dropdownWrapper.classList.add('dropdown-menu');
 
-    let groupHeader = document.createElement('h2')
-    groupHeader.classList.add('dropdown-header')
-    groupHeader.setAttribute('id', 'action-button-dropdown-header');
-    groupHeader.innerHTML = 'CourtListener'
-    dropdownWrapper.appendChild(groupHeader)
+  let groupHeader = document.createElement('h2');
+  groupHeader.classList.add('dropdown-header');
+  groupHeader.setAttribute('id', 'action-button-dropdown-header');
+  groupHeader.innerHTML = 'CourtListener';
+  dropdownWrapper.appendChild(groupHeader);
 
-    let viewOnClLi = document.createElement('li')
-    viewOnClLi.setAttribute('id', 'view-docket-button')
-    let viewOnCl = document.createElement('a')
-    viewOnCl.innerHTML = 'View this docket'
-    viewOnCl.href = `https://www.courtlistener.com/recap/gov.uscourts.${court}.${pacerCaseId}/`
-    viewOnCl.setAttribute('target', '_blank');
-    viewOnClLi.appendChild(viewOnCl)
-    dropdownWrapper.appendChild(viewOnClLi)
+  let viewOnClLi = document.createElement('li');
+  viewOnClLi.setAttribute('id', 'view-docket-button');
+  let viewOnCl = document.createElement('a');
+  viewOnCl.innerHTML = 'View this docket';
+  viewOnCl.href = `https://www.courtlistener.com/recap/gov.uscourts.${court}.${pacerCaseId}/`;
+  viewOnCl.setAttribute('target', '_blank');
+  viewOnClLi.appendChild(viewOnCl);
+  dropdownWrapper.appendChild(viewOnClLi);
 
-    let divider2 = document.createElement('div')
-    divider2.classList.add("recap-dropdown-divider")
-    dropdownWrapper.appendChild(divider2)
+  let divider2 = document.createElement('div');
+  divider2.classList.add('recap-dropdown-divider');
+  dropdownWrapper.appendChild(divider2);
 
-    let checkLi = document.createElement('li')
-    let checkDoc = document.createElement('a')
-    checkDoc.innerHTML = 'Refresh RECAP Links'
-    checkDoc.setAttribute('href', 'javascript:void(0);')
-    checkDoc.setAttribute('id', 'refresh-recap-links')
-    checkDoc.setAttribute('role', 'button')
+  let checkLi = document.createElement('li');
+  let checkDoc = document.createElement('a');
+  checkDoc.innerHTML = 'Refresh RECAP Links';
+  checkDoc.setAttribute('href', 'javascript:void(0);');
+  checkDoc.setAttribute('id', 'refresh-recap-links');
+  checkDoc.setAttribute('role', 'button');
 
-    checkLi.appendChild(checkDoc)
-    dropdownWrapper.appendChild(checkLi)
+  checkLi.appendChild(checkDoc);
+  dropdownWrapper.appendChild(checkLi);
 
-    return dropdownWrapper
-}
+  return dropdownWrapper;
+};
 
 // creates a single button with a dropdown toggle menu
 const recapActionsButton = (court, pacerCaseId) => {
   const mainDiv = document.createElement('div');
-  mainDiv.classList.add('btn-group')
-  mainDiv.setAttribute('id', 'recap-action-button')
+  mainDiv.classList.add('btn-group');
+  mainDiv.setAttribute('id', 'recap-action-button');
 
-  const spinner = document.createElement('i')
-  spinner.classList.add("fa", "fa-spinner", "fa-spin")
-  spinner.setAttribute('id', 'recap-button-spinner')
-  spinner.classList.add('recap-btn-spinner-hidden')
+  const spinner = document.createElement('i');
+  spinner.classList.add('fa', 'fa-spinner', 'fa-spin');
+  spinner.setAttribute('id', 'recap-button-spinner');
+  spinner.classList.add('recap-btn-spinner-hidden');
 
   const mainButton = document.createElement('a');
   mainButton.classList.add('btn', 'btn-primary', 'dropdown-toggle');
-  mainButton.innerHTML = `${spinner.outerHTML} RECAP Actions`
-  mainButton.setAttribute('data-toggle', 'dropdown')
-  mainButton.setAttribute('aria-haspopup', true)
-  mainButton.setAttribute('aria-expanded', false)
+  mainButton.innerHTML = `${spinner.outerHTML} RECAP Actions`;
+  mainButton.setAttribute('data-toggle', 'dropdown');
+  mainButton.setAttribute('aria-haspopup', true);
+  mainButton.setAttribute('aria-expanded', false);
 
   const caret = document.createElement('span');
-  caret.classList.add('caret')
+  caret.classList.add('caret');
 
-  hiddenDropdown = recapDropdownMenu(court, pacerCaseId)
+  hiddenDropdown = recapDropdownMenu(court, pacerCaseId);
 
-  mainButton.appendChild(caret)
-  mainDiv.appendChild(mainButton)
-  mainDiv.appendChild(hiddenDropdown)
+  mainButton.appendChild(caret);
+  mainDiv.appendChild(mainButton);
+  mainDiv.appendChild(hiddenDropdown);
 
-  return mainDiv
+  return mainDiv;
 };

--- a/src/action_button.js
+++ b/src/action_button.js
@@ -1,6 +1,9 @@
 // Handles the insertion of the "Create alert" option in the dropdown menu
 const addAlertButtonInRecapAction = (court, pacerCaseId) => {
   let dropdownHeader = document.getElementById('action-button-dropdown-header')
+  if (!dropdownHeader){
+    return;
+  }
   let existingAlertButton = document.getElementById('create-alert-button')
   if (!existingAlertButton) {
       let alertLi = document.createElement("li");
@@ -22,6 +25,9 @@ const addAlertButtonInRecapAction = (court, pacerCaseId) => {
 // Handles the insertion of the "Search this docket" option in the dropdown menu
 const addSearchDocketInRecapAction = (cl_id) => {
   let viewDocketButton = document.getElementById('view-docket-button')
+  if (!viewDocketButton){
+    return;
+  }
   let existingSearchButton = document.getElementById('search-docket-button')
   if (!existingSearchButton) {
     let docketLi = document.createElement('li')

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -164,7 +164,7 @@ AppellateDelegate.prototype.handleDocketDisplayPage = async function () {
 AppellateDelegate.prototype.handleAttachmentPage = async function () {
   this.pacer_case_id = await APPELLATE.getCaseId(this.tabId, this.queryParameters, this.docId);
 
-  if (this.pacer_case_id) {
+  if (!this.pacer_case_id) {
     return;
   }
 

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -43,11 +43,11 @@ AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
 AppellateDelegate.prototype.attachRecapLinksToEligibleDocs = async function () {
   // When you click a document link, it runs JS that submits this form.
   // Here, we override the target attribute of the form. If you don't do
-  // this, the form opens a new tab (target="_blank" by default), and 
-  // we would be unable to link that tab back to the metadata we 
-  // captured here. Thus, by overriding this form, we are able to 
+  // this, the form opens a new tab (target="_blank" by default), and
+  // we would be unable to link that tab back to the metadata we
+  // captured here. Thus, by overriding this form, we are able to
   // maintain the context we need to upload docs to the archive.
-  
+
   let form = document.getElementsByName('doDocPostURLForm');
   if (form.length) {
     form[0].setAttribute('target', '_self');

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -7,7 +7,7 @@ let AppellateDelegate = function (tabId, court, url, links) {
   this.recap = importInstance(Recap);
   this.notifier = importInstance(Notifier);
   this.queryParameters = APPELLATE.getQueryParameters(this.url);
-  this.docId = APPELLATE.getDocIdFromServlet(this.queryParameters.get('servlet'))
+  this.docId = APPELLATE.getDocIdFromServlet(this.queryParameters.get('servlet'));
 };
 
 // Identify the current page using the URL and the query string,
@@ -111,7 +111,7 @@ AppellateDelegate.prototype.attachRecapLinksToEligibleDocs = async function () {
 
 AppellateDelegate.prototype.handleDocketDisplayPage = async function () {
   this.pacer_case_id = await APPELLATE.getCaseId(this.tabId, this.queryParameters, this.docId);
- 
+
   if (!this.pacer_case_id) {
     return;
   }
@@ -149,8 +149,12 @@ AppellateDelegate.prototype.handleDocketDisplayPage = async function () {
       }
     };
 
-    this.recap.uploadDocket(this.court, this.pacer_case_id, document.documentElement.innerHTML, 'APPELLATE_DOCKET', (ok) =>
-      callback(ok)
+    this.recap.uploadDocket(
+      this.court,
+      this.pacer_case_id,
+      document.documentElement.innerHTML,
+      'APPELLATE_DOCKET',
+      (ok) => callback(ok)
     );
   } else {
     console.info(`RECAP: Not uploading docket. RECAP is disabled.`);
@@ -163,7 +167,7 @@ AppellateDelegate.prototype.handleAttachmentPage = async function () {
   if (this.pacer_case_id) {
     return;
   }
-  
+
   if (history.state && history.state.uploaded) {
     return;
   }

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -97,7 +97,6 @@ AppellateDelegate.prototype.attachRecapLinksToEligibleDocs = async function () {
 };
 
 AppellateDelegate.prototype.handleDocketDisplayPage = async function () {
-  // retrieve pacer_case_id from URL query parameters
   let pacer_case_id = APPELLATE.getCaseIdFromSearchQuery(this.queryParameters) || APPELLATE.getCaseIdFromInputs();
 
   // if the last step didn't find the caseId in the query parameter, It will check the storage

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -97,15 +97,10 @@ AppellateDelegate.prototype.attachRecapLinksToEligibleDocs = async function () {
 };
 
 AppellateDelegate.prototype.handleDocketDisplayPage = async function () {
-  let pacer_case_id = APPELLATE.getCaseIdFromSearchQuery(this.queryParameters) || APPELLATE.getCaseIdFromInputs();
-
-  // if the last step didn't find the caseId in the query parameter, It will check the storage
+  let pacer_case_id = await APPELLATE.getCaseId(this.tabId, this.queryParameters);
+ 
   if (!pacer_case_id) {
-    const tabStorage = await getItemsFromStorage(this.tabId);
-    if (!tabStorage && !tabStorage.caseId) {
-      return;
-    }
-    pacer_case_id = tabStorage.caseId;
+    return;
   }
 
   // Query the first table with case data and insert the RECAP actions button
@@ -154,16 +149,7 @@ AppellateDelegate.prototype.handleAttachmentPage = async function () {
     return;
   }
 
-  let pacer_case_id = APPELLATE.getCaseIdFromSearchQuery(this.queryParameters) || APPELLATE.getCaseIdFromInputs();
-
-  // if the last step didn't find the caseId in the query parameter, It will check the storage
-  if (!pacer_case_id) {
-    const tabStorage = await getItemsFromStorage(this.tabId);
-    if (!tabStorage && !tabStorage.caseId) {
-      return;
-    }
-    pacer_case_id = tabStorage.caseId;
-  }
+  let pacer_case_id = await APPELLATE.getCaseId(this.tabId, this.queryParameters);
 
   if (!pacer_case_id) {
     return;

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -41,6 +41,13 @@ AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
 
 // check every link in the document to see if RECAP has it
 AppellateDelegate.prototype.attachRecapLinksToEligibleDocs = async function () {
+  // When you click a document link, it runs JS that submits this form.
+  // Here, we override the target attribute of the form. If you don't do
+  // this, the form opens a new tab (target="_blank" by default), and 
+  // we would be unable to link that tab back to the metadata we 
+  // captured here. Thus, by overriding this form, we are able to 
+  // maintain the context we need to upload docs to the archive.
+  
   let form = document.getElementsByName('doDocPostURLForm');
   if (form.length) {
     form[0].setAttribute('target', '_self');

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -86,7 +86,8 @@ let APPELLATE = {
 
   // Create a list of doc_ids from the list of all links available on the page
   findDocLinksFromAnchors: (nodeList) => {
-    const links = [];
+    let links = [];
+    let docsToCases = {};
     Array.from(nodeList).map((a) => {
       if (!PACER.isDocumentUrl(a.href)) return;
 
@@ -96,6 +97,7 @@ let APPELLATE = {
       let params = {};
       if (doDocPost) {
         [, params.doc_id, params.case_id] = doDocPost;
+        docsToCases[params.doc_id] = params.case_id;
       }
 
       a.removeAttribute('onclick');
@@ -118,19 +120,23 @@ let APPELLATE = {
       let docId = PACER.getDocumentIdFromUrl(a.href);
       links.push(docId);
     });
-    return links;
+    return [links, docsToCases];
   },
 
-  // Create dummy iframe to use as a target for the forms on different pages
-  createDummyIframe: (name) => {
-    // A few pages from Appellate PACER use a hidden form that is submitted when an
-    // anchor link is clicked. This hidden form has its target attribute set to open
-    // a new tab, so We're using this iframe to change the target of the hidden form
-    // and avoid opening multiple tabs for the same PACER case.
-    let iframe = document.createElement('iframe');
-    iframe.setAttribute('name', name);
-    iframe.setAttribute('id', name);
-    iframe.style.display = 'none';
-    document.body.appendChild(iframe);
+  // get the docId from the servelet parameter of the attachment page or the single doc page
+  getDocIdFromServlet: (servlet) => {
+    if (!servlet) {
+      return;
+    }
+
+    let docString = /^ShowDoc\/(\d+)/.exec(servlet);
+
+    if (!docString) {
+      return;
+    }
+
+    let [_, docId] = docString;
+
+    return docId;
   },
 };

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -7,9 +7,9 @@ let APPELLATE = {
 
   // returns the servlet parameter from the inputs on the page
   getServletFromInputs: () => {
-    // Appellate PACER uses the servlet parameter to identify pages. This parameter 
+    // Appellate PACER uses the servlet parameter to identify pages. This parameter
     // can be usually found in the URL's query string but there's also a hidden input
-    // on some pages that has the same name and value, so We can use it to identify 
+    // on some pages that has the same name and value, so We can use it to identify
     // the page when the parameter is not present in the URL like in the Case Selection
     // page.
     let input = document.querySelector('input[name=servlet]');
@@ -23,15 +23,15 @@ let APPELLATE = {
   },
 
   // returns the pacer_case_id from the URL's query string if its available
-  getCaseIdFromSearchQuery: (queryParameters) =>{
-    let pacer_case_id = queryParameters.get('caseid') || queryParameters.get('caseId')
-    return pacer_case_id
+  getCaseIdFromSearchQuery: (queryParameters) => {
+    let pacer_case_id = queryParameters.get('caseid') || queryParameters.get('caseId');
+    return pacer_case_id;
   },
 
   // Returns true if this is a "Attachment page"
-  isAttachmentPage: () =>{
-    let form = document.getElementsByName('dktEntry')
-    return form.length !== 0
+  isAttachmentPage: () => {
+    let form = document.querySelector("form[name='dktEntry']");
+    return form !== null;
   },
 
   // Returns true if the URL is for the case selection page.
@@ -80,8 +80,8 @@ let APPELLATE = {
     const links = [];
     Array.from(nodeList).map((a) => {
       if (!PACER.isDocumentUrl(a.href)) return;
-      
-      // this regex will match the doc_id and case_id passed as an argument in the  
+
+      // this regex will match the doc_id and case_id passed as an argument in the
       // onclick event of each anchor element related to a document
       let doDocPost = /^return doDocPostURL\('([^']*)','([^']*)'\);/.exec(a.getAttribute('onclick'));
       let params = {};
@@ -112,11 +112,11 @@ let APPELLATE = {
     return links;
   },
 
-  // Create dummy iframe to use as a target for the forms on different pages 
+  // Create dummy iframe to use as a target for the forms on different pages
   createDummyIframe: (name) => {
-    // A few pages from Appellate PACER use a hidden form that is submitted when an 
+    // A few pages from Appellate PACER use a hidden form that is submitted when an
     // anchor link is clicked. This hidden form has its target attribute set to open
-    // a new tab, so We're using this iframe to change the target of the hidden form 
+    // a new tab, so We're using this iframe to change the target of the hidden form
     // and avoid opening multiple tabs for the same PACER case.
     let iframe = document.createElement('iframe');
     iframe.setAttribute('name', name);

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -123,17 +123,13 @@ let APPELLATE = {
     return { links, docsToCases };
   },
 
-  // get the docId from the servelet parameter of the attachment page or the single doc page
+  // get the docId from the servlet parameter of the attachment page or the single doc page
   getDocIdFromServlet: (servlet) => {
-    if (!servlet) {
-      return;
-    }
+    if (!servlet) return;
 
     let docString = /^ShowDoc\/(\d+)/.exec(servlet);
 
-    if (!docString) {
-      return;
-    }
+    if (!docString) return;
 
     let [_, docId] = docString;
 

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -20,7 +20,7 @@ let APPELLATE = {
   //
   //   - Check the URL's query string if its available
   //   - Check inputs on the page
-  //   - Check collection of docId and caseId 
+  //   - Check collection of docId and caseId
   //   - Check the storage
   getCaseId: async (tabId, queryParameters, docId) => {
     let input = document.querySelector('input[name=caseId]');
@@ -97,13 +97,9 @@ let APPELLATE = {
     Array.from(nodeList).map((a) => {
       if (!PACER.isDocumentUrl(a.href)) return;
 
-      // this regex will match the doc_id and case_id passed as an argument in the
-      // onclick event of each anchor element related to a document
-      let doDocPost = /^return doDocPostURL\('([^']*)','([^']*)'\);/.exec(a.getAttribute('onclick'));
-      let params = {};
-      if (doDocPost) {
-        [, params.doc_id, params.case_id] = doDocPost;
-        docsToCases[params.doc_id] = params.case_id;
+      let doDoc = PACER.parseDoDocPostURL(a.getAttribute('onclick'));
+      if (doDoc && doDoc.doc_id && doDoc.case_id) {
+        docsToCases[doDoc.doc_id] = doDoc.case_id;
       }
 
       a.removeAttribute('onclick');

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -20,10 +20,16 @@ let APPELLATE = {
   //
   //   - Check the URL's query string if its available
   //   - Check inputs on the page
+  //   - Check collection of docId and caseId 
   //   - Check the storage
-  getCaseId: async (tabId, queryParameters) => {
+  getCaseId: async (tabId, queryParameters, docId) => {
     let input = document.querySelector('input[name=caseId]');
     let pacer_case_id = queryParameters.get('caseid') || queryParameters.get('caseId') || (input && input.value);
+
+    // try to get a mapping from a pacer_doc_id in the URL to the pacer_case_id
+    if (!pacer_case_id && docId) {
+      pacer_case_id = await getPacerCaseIdFromPacerDocId(tabId, docId);
+    }
 
     // if the last step didn't find the caseId, It will check the storage
     if (!pacer_case_id) {

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -16,15 +16,24 @@ let APPELLATE = {
     if (input) return input.value;
   },
 
-  // returns the pacer_case_id from the inputs on the page
-  getCaseIdFromInputs: () => {
+  // tries to retrieve the pacer_case_id using different approaches:
+  //
+  //   - Check the URL's query string if its available
+  //   - Check inputs on the page
+  //   - Check the storage
+  getCaseId: async (tabId, queryParameters) => {
     let input = document.querySelector('input[name=caseId]');
-    if (input) return input.value;
-  },
+    let pacer_case_id = queryParameters.get('caseid') || queryParameters.get('caseId') || (input && input.value);
 
-  // returns the pacer_case_id from the URL's query string if its available
-  getCaseIdFromSearchQuery: (queryParameters) => {
-    let pacer_case_id = queryParameters.get('caseid') || queryParameters.get('caseId');
+    // if the last step didn't find the caseId, It will check the storage
+    if (!pacer_case_id) {
+      const tabStorage = await getItemsFromStorage(tabId);
+      if (!tabStorage && !tabStorage.caseId) {
+        return;
+      }
+      pacer_case_id = tabStorage.caseId;
+    }
+
     return pacer_case_id;
   },
 

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -120,7 +120,7 @@ let APPELLATE = {
       let docId = PACER.getDocumentIdFromUrl(a.href);
       links.push(docId);
     });
-    return [links, docsToCases];
+    return { links, docsToCases };
   },
 
   // get the docId from the servelet parameter of the attachment page or the single doc page

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -349,7 +349,7 @@ ContentDelegate.prototype.handleAttachmentMenuPage = function () {
       }, this);
 
       this.recap.uploadAttachmentMenu(this.court, this.pacer_case_id,
-        document.documentElement.innerHTML, callback);
+        document.documentElement.innerHTML, 'ATTACHMENT_PAGE', callback);
     } else {
       console.info("RECAP: Not uploading attachment menu. RECAP is disabled.");
     }

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -397,6 +397,24 @@ let PACER = {
     return r;
   },
 
+  // Parse the doDocPostURL function returning its parameters as a dict.
+  parseDoDocPostURL: function(doDoc_string){
+    // CMECF provides extra information on Document Links in the onclick event
+    // function doDocPostURL(), e.g.:
+    //
+    //   return doDocPostURL('009031927529','318547');
+    //
+    // this regex will match the doc_id and case_id passed as an argument in the
+    // onclick event of each anchor element related to a document from Appellate Pacer.
+    let doDocPost = /^return doDocPostURL\('([^']*)','([^']*)'\);/.exec(doDoc_string);
+    if (!doDocPost) {
+      return;
+    }
+    let params = {};
+    [, params.doc_id, params.case_id] = doDocPost;
+    return params;
+  },
+
   // Given document.cookie, returns true if the user is logged in to PACER.
   hasPacerCookie: function (cookieString) {
     let cookies = {};

--- a/src/recap.js
+++ b/src/recap.js
@@ -123,11 +123,11 @@ function Recap() {
 
     // Uploads a "Document Selection Menu" page to the RECAP server, calling
     // the callback with a boolean success flag.
-    uploadAttachmentMenu: function (pacer_court, pacer_case_id, html, cb) {
+    uploadAttachmentMenu: function (pacer_court, pacer_case_id, html, upload_type, cb) {
       let formData = new FormData();
       formData.append('court', PACER.convertToCourtListenerCourt(pacer_court));
       pacer_case_id && formData.append('pacer_case_id', pacer_case_id);
-      formData.append('upload_type', UPLOAD_TYPES['ATTACHMENT_PAGE']);
+      formData.append('upload_type', UPLOAD_TYPES[upload_type]);
       formData.append('filepath_local', new Blob([html], { type: 'text/html' }));
       formData.append('debug', DEBUG);
       $.ajax({


### PR DESCRIPTION
This PR adds support for the attachment page from Appellate PACER to the RECAP extension.

This PR will introduce the following changes:

- This PR adds a new parameter called **upload_type** to the **uploadAttachmentMenu** method. The current implementation of this method only uploads attachment pages from district PACER.  This new parameter will allow us to use the same function to upload attachment pages from appellate PACER.

-  A new method to get the `Servlet` parameter will be added. This new method will use hidden `inputs` on the page to get it.

- This PR will refactor the  **dispatchHandler** method. The new method to get the Servlet parameter will allow us to easily identify the **case selection page**.

- The current implementation of the `AppellateDelegate` class is not able to upload the **full docket page**, this class is not able to identify it using the page's URL but, this PR will fix that issue using the new method that gets the `Servlet` parameter from inputs on the page.

- Two new functions to get the `caseId` will be added. One of these functions uses the query string of the URL while the other one tries to get this id from inputs on the page.

- This PR will add a helper function that creates an iframe element on the **case summary** and **full docket page**. We will use the iframe to change the default behavior of a hidden `form` on these pages. This hidden form is submitted when an `anchor` element related to a document is clicked and its **target attribute** is set to `_blank`, so a tab is open every time we click one of those links. Changing the target attribute of the `form` will allow us to keep using the same tab ( using the same tab is preferred because the RECAP extension uses the `tab id` as a key to save data to the local storage. If a document is open in a different tab, the extension won't be able to get the data that was previously saved in the local storage).

- The logic used to filter links related to documents on the page will be updated to add the creation of a listener that avoids opening new tabs when these links are clicked.


The changes included in this PR will fix https://github.com/freelawproject/recap/issues/315