### PR TITLE
feat(caseQueryAdvanced): Add support to identify this page from PACER

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
  - None yet
 
 Fixes: 
- - None yet
+ - More robust uploading of case query pages([#321](https://github.com/freelawproject/recap/issues/321), [#2419](https://github.com/freelawproject/courtlistener/issues/2419),)
 
 For developers:
  - Nothing yet

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -314,7 +314,7 @@ describe('The Recap export module', function () {
       expected.append('filepath_local', new Blob(
         [html], { type: type }), filename);
 
-      recap.uploadIQueryPage(court, pacer_case_id, html, function () { });
+      recap.uploadIQueryPage(court, pacer_case_id, html, 'IQUERY_PAGE', function () { });
       const actualData = jasmine.Ajax.requests.mostRecent().data();
       expect(actualData).toEqual(jasmine.objectContaining(expected));
     });

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -161,6 +161,8 @@ AppellateDelegate.prototype.handleDocketDisplayPage = async function () {
     return;
   }
 
+  await saveCaseIdinTabStorage({ tabId: this.tabId }, this.pacer_case_id);
+
   // Query the first table with case data and insert the RECAP actions button
   let table = document.querySelectorAll('table')[3];
   let button = recapActionsButton(this.court, this.pacer_case_id, false);

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -35,8 +35,33 @@ AppellateDelegate.prototype.dispatchPageHandler = function () {
 
 AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
   // retrieve pacer_case_id from the link related to the Case Query
-  this.pacer_case_id = APPELLATE.getCaseIdFromCaseSelection();
-  await saveCaseIdinTabStorage({ tabId: this.tabId }, this.pacer_case_id);
+  if (document.getElementsByName('csnum1')[0].value || document.getElementsByName('csnum2')[0].value){
+    this.pacer_case_id = APPELLATE.getCaseIdFromCaseSelection();
+    await saveCaseIdinTabStorage({ tabId: this.tabId }, this.pacer_case_id);
+  }
+  
+  const options = await getItemsFromStorage('options');
+  
+  if (!options['recap_enabled']) {
+    console.info('RECAP: Not uploading case selection page. RECAP is disabled.');
+    return;
+  }
+
+  let callback = (ok) => {
+    if (ok) {
+      history.replaceState({ uploaded: true }, '');
+      this.notifier.showUpload('Case selection page uploaded to the public RECAP Archive.', function () {});
+    }
+  };
+
+  this.recap.uploadIQueryPage(
+    this.court,
+    null,
+    document.documentElement.innerHTML,
+    'APPELLATE_CASE_QUERY_RESULT_PAGE',
+    callback
+  );
+  
 };
 
 // check every link in the document to see if RECAP has it

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -65,6 +65,53 @@ let APPELLATE = {
     return /servlet\/TransportRoom/.test(url) && !/[?&]/.test(url);
   },
 
+  // Returns true if the case selection page has one row.
+  caseSelectionPageHasOneRow: () => {
+    // The Case Selection Page from Appellate shows cases that match the user's search criteria defined 
+    // on the Case Search page. This case selection can show multiple cases and has a few hidden inputs. 
+    // The csnum1 and csnum2 are two of them. These hidden input fields are populated in the following cases:
+    //
+    // - When the Case Selection Page shows one case because the user used the Case Number/Range field 
+    // to find a case by case number (csnum1 is populated, csnum2 is not populated).
+    // - When the Case Selection Page shows one or more cases because the user used the Case Number/Range 
+    // field to find cases within a range of case numbers (both inputs are populated)
+    //
+    // These inputs are not populated when the user have defined another criteria on the Case Search page and 
+    // thus we will also use the number of case_ids on the page to check the number of cases listed on the page.
+
+    let anchors = document.querySelectorAll('a[href*="caseid"]');
+
+    let csnum1 = document.getElementsByName('csnum1')[0];
+    let csnum2 = document.getElementsByName('csnum2')[0];
+
+    return (csnum1.value && !csnum2.value) || anchors.length == 1;
+  },
+
+  // This method updates the href attribute of each Case Summary anchors.
+  addCaseIdToDocketSummaryLink: () => {
+    // This method extracts the pacer_case_id from each row on the Case Selection Page and appends it to
+    // the docker report link as a URL parameters so the extension can retrieve if the users select the case. 
+    // Each row in the Case selection page has the following links:
+    //
+    //  - Link to get the Docket Report Summary (This one does not have the pacer_case_id)
+    //  - Link to get the Case Query (this one has the pacer_case_id as a URL parameter)
+    //  - Link to get the Case Summary for Originating Case
+    //
+    // The extension is able to get the pacer_case_id and saves it to the tab storage when the Case Selection 
+    // shows only a case but this approach is not possible when multiple cases are listed so this method allows 
+    // us to support Case Selection pages with multiple cases.
+
+    document.querySelectorAll('a[href*="caseid"]').forEach((caseQueryAnchor) => {
+      let params = new URLSearchParams(caseQueryAnchor.href);
+      let caseId = params.get('caseId') || params.get('caseid')
+      // the Docket Report and the Case Query links are enclosed by the same HTML tag and the anchor for
+      // the Docket Report is the first element inside this tag so using the parentElement and the firstChild
+      // attribute allow us to get the desired HTML element.
+      let caseSummaryAnchor = caseQueryAnchor.parentElement.firstChild;
+      caseSummaryAnchor.setAttribute('href', `${caseSummaryAnchor.href}&caseId=${caseId}`);
+    });
+  },
+
   // Returns caseId from href attribute of Case Query link on the Case Selection Page.
   getCaseIdFromCaseSelection: () => {
     let table = document.querySelectorAll('table');

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -97,6 +97,25 @@ let APPELLATE = {
     //  - Link to get the Case Query (this one has the pacer_case_id as a URL parameter)
     //  - Link to get the Case Summary for Originating Case
     //
+    // The HTML structure of a row is the following:
+    //   
+    //  <tr>
+    //    <td>
+    //      <a href='TransportRoom?servlet=CaseSummary.jsp&amp;caseNum=20-15021'> 
+    //        20-15021 
+    //      </a>
+    //      <a href='TransportRoom?servlet=CaseQuery.jsp&caseid=318557&csnum1=20-15021'> 
+    //        Edward Ray, Jr. v. A. Ribera, et al 
+    //      </a>
+    //    </td>
+    //    ...
+    //    <td>
+    //      <a href='https://ecf.caed.uscourts.gov/cgi-bin/DktRpt.pl?caseNumber=1:19-cv-01561-AWI-SKO'> 
+    //        1:19-cv-01561-AWI-SKO 
+    //      </a>
+    //    </td>
+    //  </tr>
+    //
     // The extension is able to get the pacer_case_id and saves it to the tab storage when the Case Selection 
     // shows only a case but this approach is not possible when multiple cases are listed so this method allows 
     // us to support Case Selection pages with multiple cases.

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -362,14 +362,8 @@ ContentDelegate.prototype.handleiQuerySummaryPage = async function () {
     return;
   }
   
-  if (PACER.hasTransactionReceipt() && !PACER.isCaseQueryAdvance()) {
-    // when a user tries to search a case using the first/middle/last name in the iquery form
-    // they might get redirected to a list of matching people before they reach the list of cases
-    // related to that name. Currently, we are not interested in this page where the user can
-    // choose a person.
-    //
-    // This if statement will end this function early if the user reaches this unwanted page.
-
+  if (PACER.isSelectAPersonPage()) {
+    // This if statement will end this function early if the user reaches this page.
     return;
   }
 

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -156,6 +156,11 @@ let PACER = {
     return !!$('th>font:contains("Transaction Receipt")').length;
   },
 
+  // Returns true if the receipts are disabled globally
+  areTransactionReceiptsDisabled: function(cookie){
+    return cookie && cookie.value.match(/receipt=N/)
+  },
+  
   // Returns true if the description in the Transaction Receipt table is 'Search'
   isSearchPage: function(){
     return this.hasTransactionReceipt && !!$('td>font:contains(Search)').length;

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -151,6 +151,18 @@ let PACER = {
     return /iquery.pl/.test(url) && !/[?&]/.test(url)
   },
 
+  // Returns true if the page contains a Transaction Receipt table
+  hasTransactionReceipt(){
+    return !!$('th>font:contains("Transaction Receipt")').length;
+  },
+
+  // Returns true if the description in the transaction receipt is "Search" and
+  // the title of the page is "Select a Case"
+  isCaseQueryAdvance: function(){
+    let title = document.querySelector('#cmecfMainContent>h2')
+    return !!$('td>font:contains(Search)').length && /Select a Case/i.test(title.innerHTML);
+  },
+
   // Returns the URL with the case id as a query parameter. This function makes
   // sure every URL related to the Docket report has the same format
   formatDocketQueryUrl: function(url, case_id){

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -152,15 +152,43 @@ let PACER = {
   },
 
   // Returns true if the page contains a Transaction Receipt table
-  hasTransactionReceipt(){
+  hasTransactionReceipt: function(){
     return !!$('th>font:contains("Transaction Receipt")').length;
   },
 
-  // Returns true if the description in the transaction receipt is "Search" and
-  // the title of the page is "Select a Case"
+  // Returns true if the description in the Transaction Receipt table is 'Search'
+  isSearchPage: function(){
+    return this.hasTransactionReceipt && !!$('td>font:contains(Search)').length;
+  }, 
+
+  // Returns true if the user reaches the 'Select a Person' page
+  isSelectAPersonPage: function(){
+    // when a user tries to search a case using the first/middle/last name in the iquery form
+    // they might get redirected to a list of matching people before they reach the list of cases
+    // related to that name. The pacer_case_id cannot be extracted from the HTML elements on this page
+    //
+    // This function checks the description in the transaction receipt and the title of the page to
+    // to identify the 'select a person' page.
+  
+    let title = document.querySelector('#cmecfMainContent>h2');
+    return this.isSearchPage() && /Select a Person/i.test(title.innerHTML);
+  },
+
+  // Returns true if the user reaches the 'Case selection' page.
   isCaseQueryAdvance: function(){
-    let title = document.querySelector('#cmecfMainContent>h2')
-    return !!$('td>font:contains(Search)').length && /Select a Case/i.test(title.innerHTML);
+    // In district court PACER, the users usually reach the case selection page directly if they avoid 
+    // using the first/middle/last name fields in the iquery form, they reach the select a person page  
+    // otherwise.
+    //
+    // In bankruptcy court PACER, the users always reach this page after they submit the iquery form.
+    //
+    // We should upload this page because the pacer_case_id can be extracted from the HTML for each case
+    //
+    // This function uses the description in the transaction receipt and the title of the page to
+    // to identify the 'select a case' page.
+
+    let title = document.querySelector('#cmecfMainContent>h2');
+    return this.isSearchPage() && /Select a Case/i.test(title.innerHTML);
   },
 
   // Returns the URL with the case id as a query parameter. This function makes

--- a/src/recap.js
+++ b/src/recap.js
@@ -12,7 +12,9 @@ function Recap() {
       'APPELLATE_ATTACHMENT_PAGE': 6,
       'CLAIMS_REGISTER_PAGE': 9,
       'ZIP': 10,
-      'IQUERY_PAGE': 12
+      'IQUERY_PAGE': 12,
+      'CASE_QUERY_RESULT_PAGE': 14,
+      'APPELLATE_CASE_QUERY_RESULT_PAGE': 15
     };
   return {
 
@@ -130,11 +132,11 @@ function Recap() {
       });
     },
 
-    uploadIQueryPage: function(pacer_court, pacer_case_id, html, cb){
+    uploadIQueryPage: function(pacer_court, pacer_case_id, html, upload_type, cb){
       let formData = new FormData();
       formData.append('court', PACER.convertToCourtListenerCourt(pacer_court));
       pacer_case_id && formData.append('pacer_case_id', pacer_case_id);
-      formData.append('upload_type', UPLOAD_TYPES['IQUERY_PAGE']);
+      formData.append('upload_type', UPLOAD_TYPES[upload_type]);
       formData.append('filepath_local', new Blob([html], { type: 'text/html' }));
       formData.append('debug', DEBUG);
       $.ajax({

--- a/src/toolbar_button.js
+++ b/src/toolbar_button.js
@@ -72,7 +72,7 @@ function updateToolbarButton(tab) {
           url: tab.url,
           name: 'PacerPref'
         }, function (pref_cookie) {
-          if (pref_cookie && pref_cookie.value.match(/receipt=N/)) {
+          if (PACER.areTransactionReceiptsDisabled(pref_cookie)) {
             // Receipts are disabled. Show the warning.
             setTitleIcon("Receipts are disabled in your PACER settings",{
               '19': 'assets/images/warning-19.png',


### PR DESCRIPTION
This PR adds support to identify and upload the caseQueryAdvanced page from Appellate and District PACER. 

This PR will introduce the following changes:

- This PR will add new upload types to the `upload_types `array in the recap class.  These new types are `CASE_QUERY_RESULT_PAGE` and  `APPELLATE_CASE_QUERY_RESULT_PAGE`.

- A new parameter called `upload_type` will be added to the uploadIQueryPage method. The current implementation of this method only uploads **query pages** from district PACER.  This new parameter will allow us to use the same function to upload **CaseQueryAdvanced** from district PACER and **caseQuery** pages from appellate PACER.

- This PR will add new helper functions to identify the **CaseQueryAdvanced** page. These helpers use HTML elements to detect this page because relying on the URL is not enough. We noticed that this page showed the transaction receipt table at the bottom of the page and also had the title "Select a case" at the top, so we created a utility function to check if the body of the page contains the  transaction receipt table ( `hasTransactionReceipt`) and another to check the title of the page and the description in the transaction receipt table( `isCaseQueryAdvance`)

- This PR will use the new helper functions to identify the Case Query Advance page and avoid uploading this page using the wrong upload_type. 


The changes included in this PR will fix https://github.com/freelawproject/recap/issues/321 and resolve https://github.com/freelawproject/courtlistener/issues/2419.

### Additional comments 

- When a user tries to search a case using only the first/middle/last name in the iquery form ([iquery.pl](https://ecf.mied.uscourts.gov/cgi-bin/iquery.pl)), they might get redirected to a list of matching people(**"Select a Person"** page) before they reach the list of cases related to that name. This PR will avoid uploading this page because the `pacer_case_id` cannot be extracted from the HTML elements. Here's a screenshot of this page:

![image](https://user-images.githubusercontent.com/55959657/208567410-ba8c507f-7973-4e97-996b-a02b191d3a4b.png)

- Some screenshots of the pages we're identifying and uploading are shown below: 

**Case Query Advance from District PACER**
![image](https://user-images.githubusercontent.com/55959657/208566442-5c4e101b-8e39-4196-ab7a-54eae37c18e3.png)


**Case Query Advance from Bankruptcy PACER**
![image](https://user-images.githubusercontent.com/55959657/208566165-1738e822-6f99-4800-bc54-e699c7899522.png)


**Case Query Advance from Appellate PACER**
![image](https://user-images.githubusercontent.com/55959657/208564758-33f0b293-6646-4c02-b613-bc37388b334b.png)
