### PR TITLE
feat(appellate): Update AppellateDelegate class to add RECAP email banners.

### DIFF
--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -22,6 +22,9 @@ AppellateDelegate.prototype.dispatchPageHandler = function () {
     case 'CaseSelectionTable.jsp':
       this.handleCaseSelectionPage();
       break;
+    case 'CaseSearch.jsp':
+      this.handleCaseSearchPage();
+      break;
     default:
       if (APPELLATE.isAttachmentPage()) {
         this.handleAttachmentPage();
@@ -199,4 +202,15 @@ AppellateDelegate.prototype.handleAttachmentPage = async function () {
     'APPELLATE_ATTACHMENT_PAGE',
     (ok) => callback(ok)
   );
+};
+
+AppellateDelegate.prototype.handleCaseSearchPage = () => {
+  if (!PACER.hasFilingCookie(document.cookie)) {
+    return;
+  }
+
+  form = document.querySelector('form');
+  if (!document.querySelector('.recap-email-banner-full')) {
+    form.appendChild(recapEmailBanner('recap-email-banner-full'));
+  }
 };


### PR DESCRIPTION
This PR will update the appellate class to insert the RECAP email banner in the **Case Search Page**. Here are some screenshots: 

![image](https://user-images.githubusercontent.com/55959657/208671153-7899c036-a413-4c86-b113-9bfb8b25454e.png)


![image](https://user-images.githubusercontent.com/55959657/208671269-12085375-223c-4600-9d09-df18f5bcda7a.png)

The changes included in this PR will resolve https://github.com/freelawproject/recap/issues/313