### PR TITLE
fix(doc links): Add the caseId parameter to doc links in Appellate Pacer

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Changes:
 
 Fixes: 
  - More robust uploading of case query pages([#321](https://github.com/freelawproject/recap/issues/321), [#2419](https://github.com/freelawproject/courtlistener/issues/2419),)
+ - Add the caseId parameter to doc links in Appellate Pacer ([#324](https://github.com/freelawproject/recap/issues/324))
 
 For developers:
  - Nothing yet

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -177,7 +177,7 @@ let APPELLATE = {
       a.removeAttribute('onclick');
       a.setAttribute('target', '_self');
 
-      if(doDoc.case_id){
+      if(doDoc && doDoc.case_id){
         let href = a.getAttribute('href')
         a.setAttribute('href', `${href}?caseId=${doDoc.case_id}`)
       }

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -177,6 +177,11 @@ let APPELLATE = {
       a.removeAttribute('onclick');
       a.setAttribute('target', '_self');
 
+      if(doDoc.case_id){
+        let href = a.getAttribute('href')
+        a.setAttribute('href', `${href}?caseId=${doDoc.case_id}`)
+      }
+
       // clone and replace anchor elements to remove all listeners
       let clonedNode = a.cloneNode(true);
       a.replaceWith(clonedNode);


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/recap/issues/324 implementing the suggested solution.