### PR TITLE
feat(appellate): Upload case query pages to RECAP

### DIFF
--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -25,6 +25,9 @@ AppellateDelegate.prototype.dispatchPageHandler = function () {
     case 'CaseSearch.jsp':
       this.handleCaseSearchPage();
       break;
+    case 'CaseQuery.jsp':
+      this.handleCaseQueryPage();
+      break;
     default:
       if (APPELLATE.isAttachmentPage()) {
         this.handleAttachmentPage();
@@ -107,6 +110,30 @@ AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
     'APPELLATE_CASE_QUERY_RESULT_PAGE',
     callback
   );
+};
+
+// Upload the case query page to RECAP
+AppellateDelegate.prototype.handleCaseQueryPage = async function () {
+  this.pacer_case_id = await APPELLATE.getCaseId(this.tabId, this.queryParameters, this.docId);
+
+  const options = await getItemsFromStorage('options');
+
+  if (options['recap_enabled']) {
+    let callback = (ok) => {
+      if (ok) {
+        history.replaceState({ uploaded: true }, '');
+        this.notifier.showUpload('Case query page uploaded to the public RECAP Archive.', function () {});
+      }
+    };
+
+    this.recap.uploadDocket(
+      this.court,
+      this.pacer_case_id,
+      document.documentElement.innerHTML,
+      'APPELLATE_CASE_QUERY_PAGE',
+      (ok) => callback(ok)
+    );
+  }
 };
 
 // check every link in the document to see if RECAP has it

--- a/src/recap.js
+++ b/src/recap.js
@@ -13,6 +13,7 @@ function Recap() {
       'CLAIMS_REGISTER_PAGE': 9,
       'ZIP': 10,
       'IQUERY_PAGE': 12,
+      'APPELLATE_CASE_QUERY_PAGE': 13,
       'CASE_QUERY_RESULT_PAGE': 14,
       'APPELLATE_CASE_QUERY_RESULT_PAGE': 15
     };


### PR DESCRIPTION
This PR adds support to upload case query pages from appellate PACER to the RECAP Archive.  This PR resolves https://github.com/freelawproject/recap/issues/317

This PR introduces the following changes:

- Adds a new upload type to the RECAP class.
- Updates the dispatch page handler in the Appellate class to include pages with the `servlet` parameter set to `'CaseQuery.jsp`'.
- Adds a new method to the Appellate class to upload the case query pages. 
