### PR TITLE
fix(style): Fix broken icons in Firefox

### DIFF
--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -23,7 +23,8 @@
 
 @font-face {
   font-family: 'RecapFontAwesome';
-  src: url("chrome-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2");
+  src: url("chrome-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2"), 
+  url("moz-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
This PR fixes the broken icons in the setting dialog and the spinner in the docket report page in Firefox. This PR resolves https://github.com/freelawproject/recap/issues/326. 