### PR TITLE
fix(content.js): PACER cookie disables the extension

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -14,6 +14,7 @@ Changes:
 Fixes: 
  - More robust uploading of case query pages([#321](https://github.com/freelawproject/recap/issues/321), [#2419](https://github.com/freelawproject/courtlistener/issues/2419),)
  - Add the caseId parameter to doc links in Appellate Pacer ([#324](https://github.com/freelawproject/recap/issues/324))
+ - Remove checks that were disabling the extension ([#325](https://github.com/freelawproject/recap/issues/325))
 
 For developers:
  - Nothing yet

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -451,6 +451,20 @@ describe('The ContentDelegate class', function () {
           tbody.appendChild(tr);
           table.appendChild(tbody);
           document.body.appendChild(table);
+          window.chrome = {
+            extension: { getURL: jasmine.createSpy('gerURL') },
+            storage: {
+              local: {
+                get: jasmine.createSpy().and.callFake((_, cb) => {
+                  cb({
+                    [1234]: { caseId: '531591' },
+                    options: { recap_enabled: true },
+                  });
+                }),
+                set: jasmine.createSpy('set').and.callFake(function () {}),
+              },
+            },
+          };
         });
 
         it('inserts a button linking the user to a create alert page on CL', async () => {

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -2,6 +2,18 @@
 describe('The ContentDelegate class', function () {
   // 'tabId' values
   const tabId = 1234;
+  // create initial chrome object
+  window.chrome = {
+    storage: {
+      local: {
+        get: jasmine.createSpy().and.callFake(function (_, cb) {
+          cb({ options: {} });
+        }),
+        set: jasmine.createSpy('set').and.callFake(function () {}),
+        remove: jasmine.createSpy('remove').and.callFake(() => {}),
+      },
+    }
+  }
 
   // 'path' values
   const districtCourtURI = 'https://ecf.canb.uscourts.gov';
@@ -234,16 +246,6 @@ describe('The ContentDelegate class', function () {
       spyOn(PACER, 'isDocketQueryUrl').and.returnValue(false);
       cd.handleDocketQueryUrl();
       expect(PACER.hasPacerCookie).not.toHaveBeenCalled();
-    });
-
-    it('checks for a Pacer cookie', function () {
-      // test is dependent on function order of operations, but does exercise all existing branches
-      const cd = nonsenseUrlContentDelegate;
-      spyOn(cd.recap, 'getAvailabilityForDocket');
-      spyOn(PACER, 'hasPacerCookie').and.returnValue(false);
-      spyOn(PACER, 'isDocketQueryUrl').and.returnValue(true);
-      cd.handleDocketQueryUrl();
-      expect(cd.recap.getAvailabilityForDocket).not.toHaveBeenCalled();
     });
 
     it('handles zero results from getAvailabilityForDocket', function () {

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -59,6 +59,11 @@ AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
     // and shows 'CaseSelectionTable.jsp' as its value.
     //
     // This check avoids sending pages like the one previously described to the API.
+    form = document.querySelector('form');
+    if (!document.querySelector('.recap-email-banner-full')) {
+      form.appendChild(recapEmailBanner('recap-email-banner-full'));
+    }
+
     return;
   }
 

--- a/src/content.js
+++ b/src/content.js
@@ -18,15 +18,14 @@ function addRecapInformation(msg) {
   // destructure the msg object to get the tabId
   const { tabId } = msg;
 
-  if (!PACER.hasPacerCookie(document.cookie)) {
-    console.info(`RECAP: Taking no actions because not logged in: ${url}`);
-
+  if (PACER.isLoginPage(url)) {
+    
     let redactionConfirmation = document.getElementById('redactionConfirmation');
-
     let emailInput = document.getElementById('loginForm:loginName');
     let passwordInput = document.getElementById('loginForm:password');
 
     if (emailInput && passwordInput && redactionConfirmation) {
+      console.info(`RECAP: Taking no actions because not logged in: ${url}`);
       removeFilingState(msg);
     }
 

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -123,10 +123,7 @@ ContentDelegate.prototype.checkRestrictions = function () {
 // Use a variety of approaches to get and store pacer_doc_id to pacer_case_id
 // mappings in local storage.
 ContentDelegate.prototype.findAndStorePacerDocIds = async function () {
-  if (!PACER.hasPacerCookie(document.cookie)) {
-    return;
-  }
-
+  
   // Not all pages have a case ID, and there are corner-cases in merged dockets
   // where there are links to documents on another case.
   let page_pacer_case_id = this.pacer_case_id
@@ -206,12 +203,7 @@ ContentDelegate.prototype.handleDocketQueryUrl = function () {
   if (!PACER.isDocketQueryUrl(this.url)) {
     return;
   }
-  // Logged out users that load a docket page, see a login page, so they
-  // shouldn't check for docket availability.
-  if (!PACER.hasPacerCookie(document.cookie)) {
-    return;
-  }
-
+  
   this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, (result) => {
     if (result.count === 0) {
       console.warn('RECAP: Zero results found for docket lookup.');

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -54,6 +54,11 @@ let PACER = {
     return match ? match[2] : null;
   },
 
+  // Returns true if the URL is for the login page
+  isLoginPage: function(url) {
+    return this.getCourtFromUrl(url) === 'login';
+  },
+
   convertToCourtListenerCourt: function(pacer_court_id) {
     return PACER_TO_CL_IDS[pacer_court_id] || pacer_court_id;
   },


### PR DESCRIPTION
This PR removes the checks using the PACER cookie, adds a new helper method to identify the login page, and updates the tests that use the cookie. This PR resolves https://github.com/freelawproject/recap/issues/325

I also noticed that the extension should do something when the user gets shown the `form` from the **case search page**  in the **case selection page**. The extension is returning early in cases like this but it seems like the extension is not working properly, so I think We should insert the recap email banner on this page.

Here's a gif showing how the current implementation handles the previous case:

![Appellate-case-selection](https://user-images.githubusercontent.com/55959657/210036476-c16c7eb2-1d72-447a-bb84-ce723c5d54d4.gif)


Here's a gif with the changes from this PR:

![Appellate-case-selection-fix](https://user-images.githubusercontent.com/55959657/210036099-d8be9616-0330-45da-9c9c-4cf51e0af5c5.gif)
