### PR TITLE
feat(appellate): Reference district cases from Appellate

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -16,3 +16,7 @@ d891dad8127683ab8263d61b1bee71db0d08a4ef
 
 # Change code styling in action_button.js
 d36f8b36a38873b775efd7edd30bbed4b3ceaa66
+
+
+# Change code styling in PacerSpec.js
+6ba14263488b72bd992ccad3793e975556ff2fcd

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -1,54 +1,52 @@
-describe('The PACER module', function() {
-  
+describe('The PACER module', function () {
   const nonsenseUrl = 'http://something.uscourts.gov/foobar/baz';
   const maliciousUrl = 'https://ecf.canb.uscourts.gov.evilsite.com/';
   const noTrailingSlashUrl = 'https://ecf.canb.uscourts.gov';
-  const docketReportURL = 'https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl'
+  const docketReportURL = 'https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl';
   const singleDocUrl = 'https://ecf.canb.uscourts.gov/doc1/034031424909';
-  const docketQueryUrl = ('https://ecf.canb.uscourts.gov/cgi-bin/' +
-    'HistDocQry.pl?531316');
-  const docketQueryUrlFromAppellate = ('https://ecf.canb.uscourts.gov/cgi-bin/' +
-    'DktRpt.pl?caseNumber=2:16-cv-01129-RFB-DJA');
-  const docketQueryUrlWithMultiParameter = ('https://ecf.canb.uscourts.gov/cgi-bin/' +
-    'DktRpt.pl?caseNumber=1:17-cv-10577&caseId=0'); 
+  const docketQueryUrl = 'https://ecf.canb.uscourts.gov/cgi-bin/' + 'HistDocQry.pl?531316';
+  const docketQueryUrlFromAppellate =
+    'https://ecf.canb.uscourts.gov/cgi-bin/' + 'DktRpt.pl?caseNumber=2:16-cv-01129-RFB-DJA';
+  const docketQueryUrlWithMultiParameter =
+    'https://ecf.canb.uscourts.gov/cgi-bin/' + 'DktRpt.pl?caseNumber=1:17-cv-10577&caseId=0';
   const appellateDocumentUrl = 'https://ecf.ca2.uscourts.gov/docs1/00205695758';
 
   function InputContainer() {
-    document.body.innerHTML=''
+    document.body.innerHTML = '';
     const inputContainer = document.createElement('div');
     inputContainer.id = 'cmecfMainContent';
-    return inputContainer
+    return inputContainer;
   }
 
   function removeInputContainer() {
     document.getElementById('cmecfMainContent').remove();
   }
 
-  function InputWithValue(value, type='button') {
+  function InputWithValue(value, type = 'button') {
     const input = document.createElement('input');
     input.value = value;
-    input.type = type
-    return input
+    input.type = type;
+    return input;
   }
 
-  describe('getCourtFromUrl', function() {
-    it('matches a valid docket query URL', function() {
+  describe('getCourtFromUrl', function () {
+    it('matches a valid docket query URL', function () {
       expect(PACER.getCourtFromUrl(docketQueryUrl)).toBe('canb');
     });
 
-    it('matches a valid single doc URL', function() {
+    it('matches a valid single doc URL', function () {
       expect(PACER.getCourtFromUrl(singleDocUrl)).toBe('canb');
     });
 
-    it('ignores patent nonsense', function() {
+    it('ignores patent nonsense', function () {
       expect(PACER.getCourtFromUrl(nonsenseUrl)).toBe(null);
     });
 
-    it('cannot be fooled by extra subdomains', function() {
+    it('cannot be fooled by extra subdomains', function () {
       expect(PACER.getCourtFromUrl(maliciousUrl)).toBe(null);
     });
 
-    it('matches even if trailing slash is absent', function() {
+    it('matches even if trailing slash is absent', function () {
       expect(PACER.getCourtFromUrl(noTrailingSlashUrl)).toBe('canb');
     });
   });
@@ -62,243 +60,235 @@ describe('The PACER module', function() {
     });
   });
 
-  describe('isDocumentUrl', function() {
-    it('matches a valid document URL', function() {
+  describe('isDocumentUrl', function () {
+    it('matches a valid document URL', function () {
       expect(PACER.isDocumentUrl(singleDocUrl)).toBe(true);
     });
 
-    it('matches a valid appellate document URL', function() {
+    it('matches a valid appellate document URL', function () {
       expect(PACER.isDocumentUrl(appellateDocumentUrl)).toBe(true);
     });
 
-    const showDocUrl = ('https://ecf.cacd.uscourts.gov/cgi-bin/show_doc.pl?' +
-      'caseid=560453&de_seq_num=24&dm_id=15521444&doc_num=7');
+    const showDocUrl =
+      'https://ecf.cacd.uscourts.gov/cgi-bin/show_doc.pl?' + 'caseid=560453&de_seq_num=24&dm_id=15521444&doc_num=7';
 
-    it('matches a valid show_doc document URL', function() {
+    it('matches a valid show_doc document URL', function () {
       expect(PACER.isDocumentUrl(showDocUrl)).toBe(true);
     });
 
-    it('returns false for a non-document court URL', function() {
+    it('returns false for a non-document court URL', function () {
       expect(PACER.isDocumentUrl(docketQueryUrl)).toBe(false);
     });
 
-    it('returns false for patent nonsense', function() {
+    it('returns false for patent nonsense', function () {
       expect(PACER.isDocumentUrl(nonsenseUrl)).toBe(false);
     });
   });
 
-  describe('isDocketQueryUrl', function() {
-    it('matches a docket query URL with digits in the query string', function() {
+  describe('isDocketQueryUrl', function () {
+    it('matches a docket query URL with digits in the query string', function () {
       expect(PACER.isDocketQueryUrl(docketQueryUrl)).toBe(true);
     });
 
-    it('matches a docket query URL with one parameter in the query string', function(){
+    it('matches a docket query URL with one parameter in the query string', function () {
       expect(PACER.isDocketQueryUrl(docketQueryUrlFromAppellate)).toBe(true);
     });
 
-    it ('matches a docket query URL with multiple parameters in the query string', function(){
+    it('matches a docket query URL with multiple parameters in the query string', function () {
       expect(PACER.isDocketQueryUrl(docketQueryUrlWithMultiParameter)).toBe(true);
     });
 
-    it ('returns false for a docket query URL that does not have querystring', function(){
+    it('returns false for a docket query URL that does not have querystring', function () {
       expect(PACER.isDocketQueryUrl(docketReportURL)).toBe(false);
     });
 
-    it('returns false for a document URL', function() {
+    it('returns false for a document URL', function () {
       expect(PACER.isDocketQueryUrl(singleDocUrl)).toBe(false);
     });
 
-    it('returns false for patent nonsense', function() {
+    it('returns false for patent nonsense', function () {
       expect(PACER.isDocketQueryUrl(nonsenseUrl)).toBe(false);
     });
   });
 
-  describe('isDocketDisplayUrl', function() {
-    const docketDisplayUrl = ('https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl?' +
-      '101092135737069-L_1_0-1');
+  describe('isDocketDisplayUrl', function () {
+    const docketDisplayUrl = 'https://ecf.canb.uscourts.gov/cgi-bin/DktRpt.pl?' + '101092135737069-L_1_0-1';
 
-    it('matches a docket display URL', function() {
+    it('matches a docket display URL', function () {
       expect(PACER.isDocketDisplayUrl(docketDisplayUrl)).toBe(true);
     });
 
-    it('returns false for a docket query URL', function() {
+    it('returns false for a docket query URL', function () {
       expect(PACER.isDocketDisplayUrl(docketQueryUrl)).toBe(false);
     });
 
-    it('returns false for a document URL', function() {
+    it('returns false for a document URL', function () {
       expect(PACER.isDocketDisplayUrl(singleDocUrl)).toBe(false);
     });
 
-    it('returns false for patent nonsense', function() {
+    it('returns false for patent nonsense', function () {
       expect(PACER.isDocketDisplayUrl(nonsenseUrl)).toBe(false);
     });
 
-    const caseDefault = 'https://ecf.ca1.uscourts.gov/n/beam/servlet/TransportRoom?' +
-      'servlet=Nonsense.jsp';
+    const caseDefault = 'https://ecf.ca1.uscourts.gov/n/beam/servlet/TransportRoom?' + 'servlet=Nonsense.jsp';
 
-    it('returns false for other jsp pages', function() {
+    it('returns false for other jsp pages', function () {
       expect(PACER.isDocketDisplayUrl(caseDefault)).toBe(false);
     });
 
-    const caseSearch = 'https://ecf.ca1.uscourts.gov/n/beam/servlet/TransportRoom?' +
-      'servlet=CaseSearch.jsp';
+    const caseSearch = 'https://ecf.ca1.uscourts.gov/n/beam/servlet/TransportRoom?' + 'servlet=CaseSearch.jsp';
 
-    it('returns false for other jsp pages', function() {
+    it('returns false for other jsp pages', function () {
       expect(PACER.isDocketDisplayUrl(caseSearch)).toBe(false);
     });
   });
 
-  describe('isDocketHistoryDisplayUrl', function() {
+  describe('isDocketHistoryDisplayUrl', function () {
     const historyUrl = 'https://ecf.ca1.uscourts.gov/HistDocQry.pl?fred-fred';
     it('should recognize a history url', function () {
       expect(PACER.isDocketHistoryDisplayUrl(historyUrl)).toBe(true);
     });
   });
 
-  describe('formatDocketQueryUrl', function(){
+  describe('formatDocketQueryUrl', function () {
     it('should return a properly formatted URL', function () {
-      expect(PACER.formatDocketQueryUrl(docketReportURL, 365816)).toBe(docketReportURL+'?365816');
+      expect(PACER.formatDocketQueryUrl(docketReportURL, 365816)).toBe(docketReportURL + '?365816');
     });
-    
+
     it('should not change if not needed', function () {
-      expect(PACER.formatDocketQueryUrl(docketReportURL+'?365816', 365816)).toBe(docketReportURL+'?365816');
+      expect(PACER.formatDocketQueryUrl(docketReportURL + '?365816', 365816)).toBe(docketReportURL + '?365816');
     });
-  })
-
-  describe('isAttachmentMenuPage', function() {
-
-    describe('for documents with a matching input for PACER 1.6 or older', function() {
-      beforeEach(function() {
-        let main_div = InputContainer()
-        main_div.appendChild(InputWithValue('Download All', 'button'))
-        document.body.appendChild(main_div)
-        document.getElementById = jasmine.createSpy('getElementById').and.callFake((id)=>{
-          if (id != 'cmecfMainContent'){
-            return null 
-          }
-          return main_div
-        });
-      });
-
-      afterEach(function() {
-        removeInputContainer();
-      });
-
-      it('returns true when the URL is valid', function() {
-        expect(PACER.isAttachmentMenuPage(singleDocUrl, document)).toBe(true);
-      });
-
-      it('returns false when the URL is invalid', function() {
-        expect(
-          PACER.isAttachmentMenuPage(docketQueryUrl, document)).toBe(false);
-      });
-    });
-
-    describe('for documents with a matching input for PACER 1.7', function() {
-      beforeEach(function() {
-        let main_div = InputContainer()
-        main_div.appendChild(InputWithValue('View Selected', 'button'))
-        main_div.appendChild(InputWithValue('Download Selected', 'button'))
-        document.body.appendChild(main_div)
-        document.getElementById = jasmine.createSpy('getElementById').and.callFake((id)=>{
-          if (id != 'cmecfMainContent'){
-            return null 
-          }
-          return main_div
-        });
-      });
-
-      afterEach(function() {
-        removeInputContainer();
-      });
-
-      it('returns true when the URL is valid', function() {
-        expect(PACER.isAttachmentMenuPage(singleDocUrl, document)).toBe(true);
-      });
-
-      it('returns false when the URL is invalid', function() {
-        expect(
-          PACER.isAttachmentMenuPage(docketQueryUrl, document)).toBe(false);
-      });
-    });
-
-    describe('for documents with a combined size over size limit', function() {
-      beforeEach(function() {
-        let main_div = InputContainer()
-        main_div.innerHTML='You must view each document individually because the combined PDF would be over the 50 MB size limit.'
-        document.body.appendChild(main_div)
-        document.getElementById = jasmine.createSpy('getElementById').and.callFake((id)=>{
-          if (id != 'cmecfMainContent'){
-            return null 
-          }
-          return main_div
-        });
-      });
-
-      afterEach(function() {
-        removeInputContainer();
-      });
-
-      it('returns true when the URL is valid', function() {
-        expect(PACER.isAttachmentMenuPage(singleDocUrl, document)).toBe(true);
-      });
-
-      it('returns false when the URL is invalid', function() {
-        expect(
-          PACER.isAttachmentMenuPage(docketQueryUrl, document)).toBe(false);
-      });
-    });
-
-    describe('for documents which have non-matching inputs', function() {
-      beforeEach(function() {
-        let main_div = InputContainer()
-        main_div.appendChild(InputWithValue('View files'))
-        main_div.appendChild(InputWithValue('View all'))
-        document.body.appendChild(main_div)
-        document.getElementById = jasmine.createSpy('getElementById').and.callFake((id)=>{
-          if (id != 'cmecfMainContent'){
-            return null 
-          }
-          return main_div
-        });
-      });
-
-      afterEach(function() {
-        removeInputContainer();
-      });
-
-      it('returns false with valid URL', function() {
-        expect(PACER.isAttachmentMenuPage(singleDocUrl, document)).toBe(false);
-      });
-
-    });
-
-    describe('for documents which have not matching format', function(){
-      beforeEach(function() {
-        let main_div = InputContainer()
-        main_div.appendChild(document.createElement('div'))
-        document.getElementById = jasmine.createSpy('getElementById').and.callFake((id)=>{
-          if (id != 'cmecfMainContent'){
-            return null 
-          }
-          return main_div
-        });
-      });
-
-      afterEach(function() {
-        removeInputContainer();
-      });
-
-      it('returns false with a valid URL', function() {
-        expect(PACER.isAttachmentMenuPage(singleDocUrl, document)).toBe(false);
-      });
-    })
-    
   });
 
-  describe('isSingleDocumentPage', function() {
-    describe('for documents with a matching input', function() {
-      beforeEach(function() {
+  describe('isAttachmentMenuPage', function () {
+    describe('for documents with a matching input for PACER 1.6 or older', function () {
+      beforeEach(function () {
+        let main_div = InputContainer();
+        main_div.appendChild(InputWithValue('Download All', 'button'));
+        document.body.appendChild(main_div);
+        document.getElementById = jasmine.createSpy('getElementById').and.callFake((id) => {
+          if (id != 'cmecfMainContent') {
+            return null;
+          }
+          return main_div;
+        });
+      });
+
+      afterEach(function () {
+        removeInputContainer();
+      });
+
+      it('returns true when the URL is valid', function () {
+        expect(PACER.isAttachmentMenuPage(singleDocUrl, document)).toBe(true);
+      });
+
+      it('returns false when the URL is invalid', function () {
+        expect(PACER.isAttachmentMenuPage(docketQueryUrl, document)).toBe(false);
+      });
+    });
+
+    describe('for documents with a matching input for PACER 1.7', function () {
+      beforeEach(function () {
+        let main_div = InputContainer();
+        main_div.appendChild(InputWithValue('View Selected', 'button'));
+        main_div.appendChild(InputWithValue('Download Selected', 'button'));
+        document.body.appendChild(main_div);
+        document.getElementById = jasmine.createSpy('getElementById').and.callFake((id) => {
+          if (id != 'cmecfMainContent') {
+            return null;
+          }
+          return main_div;
+        });
+      });
+
+      afterEach(function () {
+        removeInputContainer();
+      });
+
+      it('returns true when the URL is valid', function () {
+        expect(PACER.isAttachmentMenuPage(singleDocUrl, document)).toBe(true);
+      });
+
+      it('returns false when the URL is invalid', function () {
+        expect(PACER.isAttachmentMenuPage(docketQueryUrl, document)).toBe(false);
+      });
+    });
+
+    describe('for documents with a combined size over size limit', function () {
+      beforeEach(function () {
+        let main_div = InputContainer();
+        main_div.innerHTML =
+          'You must view each document individually because the combined PDF would be over the 50 MB size limit.';
+        document.body.appendChild(main_div);
+        document.getElementById = jasmine.createSpy('getElementById').and.callFake((id) => {
+          if (id != 'cmecfMainContent') {
+            return null;
+          }
+          return main_div;
+        });
+      });
+
+      afterEach(function () {
+        removeInputContainer();
+      });
+
+      it('returns true when the URL is valid', function () {
+        expect(PACER.isAttachmentMenuPage(singleDocUrl, document)).toBe(true);
+      });
+
+      it('returns false when the URL is invalid', function () {
+        expect(PACER.isAttachmentMenuPage(docketQueryUrl, document)).toBe(false);
+      });
+    });
+
+    describe('for documents which have non-matching inputs', function () {
+      beforeEach(function () {
+        let main_div = InputContainer();
+        main_div.appendChild(InputWithValue('View files'));
+        main_div.appendChild(InputWithValue('View all'));
+        document.body.appendChild(main_div);
+        document.getElementById = jasmine.createSpy('getElementById').and.callFake((id) => {
+          if (id != 'cmecfMainContent') {
+            return null;
+          }
+          return main_div;
+        });
+      });
+
+      afterEach(function () {
+        removeInputContainer();
+      });
+
+      it('returns false with valid URL', function () {
+        expect(PACER.isAttachmentMenuPage(singleDocUrl, document)).toBe(false);
+      });
+    });
+
+    describe('for documents which have not matching format', function () {
+      beforeEach(function () {
+        let main_div = InputContainer();
+        main_div.appendChild(document.createElement('div'));
+        document.getElementById = jasmine.createSpy('getElementById').and.callFake((id) => {
+          if (id != 'cmecfMainContent') {
+            return null;
+          }
+          return main_div;
+        });
+      });
+
+      afterEach(function () {
+        removeInputContainer();
+      });
+
+      it('returns false with a valid URL', function () {
+        expect(PACER.isAttachmentMenuPage(singleDocUrl, document)).toBe(false);
+      });
+    });
+  });
+
+  describe('isSingleDocumentPage', function () {
+    describe('for documents with a matching input', function () {
+      beforeEach(function () {
         let main = InputContainer();
         main.appendChild(InputWithValue('View Document'));
         let table = document.createElement('table');
@@ -307,70 +297,67 @@ describe('The PACER module', function() {
         td_image.innerHTML = 'Image 1234-9876';
         tr_image.appendChild(td_image);
         table.appendChild(tr_image);
-        main.appendChild(table)
-        document.body.appendChild(main)
+        main.appendChild(table);
+        document.body.appendChild(main);
       });
 
-      afterEach(function() {
+      afterEach(function () {
         removeInputContainer();
       });
 
-      it('returns true when the URL is valid', function() {
+      it('returns true when the URL is valid', function () {
         expect(PACER.isSingleDocumentPage(singleDocUrl, document)).toBe(true);
-        
       });
 
-      it('return false when the URL is invalid', function() {
-        expect(
-          PACER.isSingleDocumentPage(docketQueryUrl, document)).toBe(false);
+      it('return false when the URL is invalid', function () {
+        expect(PACER.isSingleDocumentPage(docketQueryUrl, document)).toBe(false);
       });
     });
 
-    describe('for documents which have non-matching inputs', function() {
-      beforeEach(function() {
+    describe('for documents which have non-matching inputs', function () {
+      beforeEach(function () {
         let main = InputContainer();
-        main.appendChild(InputWithValue('Download One'))
-        main.appendChild(InputWithValue('Download Some'))
-        document.body.appendChild(main)
+        main.appendChild(InputWithValue('Download One'));
+        main.appendChild(InputWithValue('Download Some'));
+        document.body.appendChild(main);
       });
 
-      afterEach(function() {
+      afterEach(function () {
         removeInputContainer();
       });
 
-      it('returns false with valid URL', function() {
+      it('returns false with valid URL', function () {
         expect(PACER.isSingleDocumentPage(singleDocUrl, document)).toBe(false);
       });
     });
 
-    describe('for documents which have non-matching format', function() {
-      beforeEach(function() {
+    describe('for documents which have non-matching format', function () {
+      beforeEach(function () {
         let main = InputContainer();
-        main.appendChild(document.createElement('div'))
-        document.body.appendChild(main)
+        main.appendChild(document.createElement('div'));
+        document.body.appendChild(main);
       });
 
-      afterEach(function() {
+      afterEach(function () {
         removeInputContainer();
       });
-      
-      it('returns false with a valid URL', function() {
+
+      it('returns false with a valid URL', function () {
         expect(PACER.isSingleDocumentPage(singleDocUrl, document)).toBe(false);
       });
-    })
-    
+    });
   });
 
-  describe('getDocumentIdFromUrl', function() {
-    it('returns the correct document id for a valid URL', function() {
+  describe('getDocumentIdFromUrl', function () {
+    it('returns the correct document id for a valid URL', function () {
       expect(PACER.getDocumentIdFromUrl(singleDocUrl)).toBe('034031424909');
     });
 
-    it('returns the correct document id for a valid appellate URL', function() {
+    it('returns the correct document id for a valid appellate URL', function () {
       expect(PACER.getDocumentIdFromUrl(appellateDocumentUrl)).toBe('00205695758');
     });
 
-    it('coerces the fourth digit to zero', function() {
+    it('coerces the fourth digit to zero', function () {
       let fourthSetUrl = singleDocUrl.replace('034031424909', '034131424909');
       expect(PACER.getDocumentIdFromUrl(fourthSetUrl)).toBe('034031424909');
     });
@@ -379,7 +366,7 @@ describe('The PACER module', function() {
   describe('getDocumentIdFronForm', function () {
     const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','');";
     let form;
-    beforeEach(function() {
+    beforeEach(function () {
       form = document.createElement('form');
       const input = document.createElement('input');
       input.value = 'View Document';
@@ -388,7 +375,7 @@ describe('The PACER module', function() {
       document.body.appendChild(form);
     });
 
-    afterEach(function() {
+    afterEach(function () {
       form.remove();
     });
 
@@ -397,40 +384,39 @@ describe('The PACER module', function() {
     });
   });
 
-  describe('getCaseNumberFromUrl', function() {
-    it('returns the right case number for a docket query URL', function() {
+  describe('getCaseNumberFromUrl', function () {
+    it('returns the right case number for a docket query URL', function () {
       expect(PACER.getCaseNumberFromUrls([docketQueryUrl])).toBe('531316');
     });
 
-    it('returns null for a document URL', function() {
+    it('returns null for a document URL', function () {
       expect(PACER.getCaseNumberFromUrls([singleDocUrl])).toBeUndefined();
     });
 
-    it('returns null for patent nonsense', function() {
+    it('returns null for patent nonsense', function () {
       expect(PACER.getCaseNumberFromUrls([nonsenseUrl])).toBeUndefined();
     });
 
-    const cmecfUrl = ('https://ecf.cmecf.uscourts.gov/cgi-bin/' +
-      'HistDocQry.pl?0');
+    const cmecfUrl = 'https://ecf.cmecf.uscourts.gov/cgi-bin/' + 'HistDocQry.pl?0';
 
-    it('returns caseNum', function() {
+    it('returns caseNum', function () {
       expect(PACER.getCaseNumberFromUrls([cmecfUrl])).toBeUndefined();
     });
   });
 
-  describe('getCaseNumberFromInputs', function() {
+  describe('getCaseNumberFromInputs', function () {
     const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','');";
     const input = document.createElement('input');
 
-    beforeEach(function() {
+    beforeEach(function () {
       const form = document.createElement('form');
       document.body.appendChild(form);
-      input.type = 'button'
+      input.type = 'button';
       form.append(input);
       form.setAttribute('onSubmit', goDLS);
     });
 
-    afterEach(function() {
+    afterEach(function () {
       document.getElementsByTagName('form')[0].remove();
     });
 
@@ -446,21 +432,19 @@ describe('The PACER module', function() {
     });
   });
 
-  describe('getBaseNameFromUrl', function() {
-    it('gets the proper basename for a docket URL', function() {
+  describe('getBaseNameFromUrl', function () {
+    it('gets the proper basename for a docket URL', function () {
       expect(PACER.getBaseNameFromUrl(docketQueryUrl)).toBe('HistDocQry.pl');
     });
 
-    it('gets the proper basename for a document URL', function() {
-      expect(PACER.getBaseNameFromUrl(singleDocUrl)).toBe('034031424909')
+    it('gets the proper basename for a document URL', function () {
+      expect(PACER.getBaseNameFromUrl(singleDocUrl)).toBe('034031424909');
     });
   });
 
-  describe('parseGoDLSFunction', function(){
-    
-    it("gets the right values for an example DLS string", function() {
-      let goDLSSampleString = "goDLS('/doc1/09518360046','153992','264','','','1','',''); " +
-        "return(false);";
+  describe('parseGoDLSFunction', function () {
+    it('gets the right values for an example DLS string', function () {
+      let goDLSSampleString = "goDLS('/doc1/09518360046','153992','264','','','1','',''); " + 'return(false);';
       expect(PACER.parseGoDLSFunction(goDLSSampleString)).toEqual({
         hyperlink: '/doc1/09518360046',
         de_caseid: '153992',
@@ -469,14 +453,12 @@ describe('The PACER module', function() {
         pdf_header: '',
         pdf_toggle_possible: '1',
         magic_num: '',
-        hdr: ''
+        hdr: '',
       });
     });
 
-
-    it("gets the right values for a DLS string with 10 parameters", function(){
-      let goDLSSampleString = "goDLS('/doc1/152129714885','496493','','1','','','','','',''); " +
-        "return(false)";
+    it('gets the right values for a DLS string with 10 parameters', function () {
+      let goDLSSampleString = "goDLS('/doc1/152129714885','496493','','1','','','','','',''); " + 'return(false)';
       expect(PACER.parseGoDLSFunction(goDLSSampleString)).toEqual({
         hyperlink: '/doc1/152129714885',
         de_caseid: '496493',
@@ -488,130 +470,125 @@ describe('The PACER module', function() {
         claim_id: '',
         claim_num: '',
         claim_doc_seq: '',
-      })
+      });
     });
 
-    it("returns false for an invalid DLS string", function() {
-      expect(PACER.parseGoDLSFunction("not a goDLS function call")).toBe(null);
+    it('returns false for an invalid DLS string', function () {
+      expect(PACER.parseGoDLSFunction('not a goDLS function call')).toBe(null);
     });
 
-    it("returns false for a null DLS input", function() {
+    it('returns false for a null DLS input', function () {
       expect(PACER.parseGoDLSFunction(null)).toBe(null);
     });
 
-    it("returns false for an undefined DLS input", function() {
+    it('returns false for an undefined DLS input', function () {
       expect(PACER.parseGoDLSFunction(undefined)).toBe(null);
     });
   });
 
-  describe('hasPacerCookie', function() {
-    const loggedInCookie = ('PacerSession=B7yuvmcj2F...9p5nDzEXsHE; ' +
-      'PacerPref=receipt=Y');
-    const altLoggedInCookie = ('PacerUser=B7yuvmcj2F...9p5nDzEXsHE; ' +
-      'PacerPref=receipt=Y');
-    const nonLoggedInCookie = ('PacerSession=unvalidated; PacerPref=receipt=Y');
-    const nonsenseCookie = ('Foo=barbaz; Baz=bazbar; Foobar=Foobar');
+  describe('hasPacerCookie', function () {
+    const loggedInCookie = 'PacerSession=B7yuvmcj2F...9p5nDzEXsHE; ' + 'PacerPref=receipt=Y';
+    const altLoggedInCookie = 'PacerUser=B7yuvmcj2F...9p5nDzEXsHE; ' + 'PacerPref=receipt=Y';
+    const nonLoggedInCookie = 'PacerSession=unvalidated; PacerPref=receipt=Y';
+    const nonsenseCookie = 'Foo=barbaz; Baz=bazbar; Foobar=Foobar';
 
-    it('returns true for a valid logged in cookie', function() {
+    it('returns true for a valid logged in cookie', function () {
       expect(PACER.hasPacerCookie(loggedInCookie)).toBe(true);
     });
 
-    it('returns true for an alternate valid logged in cookie', function() {
+    it('returns true for an alternate valid logged in cookie', function () {
       expect(PACER.hasPacerCookie(altLoggedInCookie)).toBe(true);
     });
 
-    it('returns false for a non-logged in cookie', function() {
+    it('returns false for a non-logged in cookie', function () {
       expect(PACER.hasPacerCookie(nonLoggedInCookie)).toBe(false);
     });
 
-    it('returns false for nonsense cookie', function() {
+    it('returns false for nonsense cookie', function () {
       expect(PACER.hasPacerCookie(nonsenseCookie)).toBe(false);
     });
   });
 
-  describe('isAppellateCourt', function() {
-    it('returns true for an appellate court', function() {
+  describe('isAppellateCourt', function () {
+    it('returns true for an appellate court', function () {
       expect(PACER.isAppellateCourt('ca5')).toBe(true);
     });
 
-    it('returns false for a non-appellate court', function() {
+    it('returns false for a non-appellate court', function () {
       expect(PACER.isAppellateCourt('pawd')).toBe(false);
     });
 
-    it('returns false for patent nonsense', function() {
+    it('returns false for patent nonsense', function () {
       expect(PACER.isAppellateCourt('pingpong')).toBe(false);
     });
   });
 
-  describe('isIQuerySummaryURL', function(){
-    it('returns true for an iquery url with query string', function() {
-      expect(PACER.isIQuerySummaryURL('https://ecf.mied.uscourts.gov/cgi-bin/iquery.pl?184987019171527-L_1_0-1')).toBe(true);
+  describe('isIQuerySummaryURL', function () {
+    it('returns true for an iquery url with query string', function () {
+      expect(PACER.isIQuerySummaryURL('https://ecf.mied.uscourts.gov/cgi-bin/iquery.pl?184987019171527-L_1_0-1')).toBe(
+        true
+      );
     });
 
-    it('returns false for an iquery url without query string', function() {
+    it('returns false for an iquery url without query string', function () {
       expect(PACER.isIQuerySummaryURL('https://ecf.mied.uscourts.gov/cgi-bin/iquery.pl')).toBe(false);
     });
 
-    it('returns false for an url not related to the iquery pages', function() {
+    it('returns false for an url not related to the iquery pages', function () {
       expect(PACER.isIQuerySummaryURL(docketReportURL)).toBe(false);
     });
-  })
-  
-  
-  describe('getCaseIdFromIQuerySummary', function(){    
-    
-    describe('for documents with matching format', function() {
+  });
 
-      beforeEach(function() {
-        let main_div = InputContainer()
-        let table = document.createElement('table')
+  describe('getCaseIdFromIQuerySummary', function () {
+    describe('for documents with matching format', function () {
+      beforeEach(function () {
+        let main_div = InputContainer();
+        let table = document.createElement('table');
         let tbody = document.createElement('tbody');
         let tr = document.createElement('tr');
         let td = document.createElement('td');
-        let anchor = document.createElement('a')
-        anchor.href="cgi-bin/qryDocument.pl?360406"
-        td.appendChild(anchor)
-        tr.appendChild(td)
-        tbody.appendChild(tr)
-        table.appendChild(tbody)
-        main_div.appendChild(table)
-        document.body.appendChild(main_div)
-        document.querySelector = jasmine.createSpy('querySelector').and.callFake(()=>{
-          return table
+        let anchor = document.createElement('a');
+        anchor.href = 'cgi-bin/qryDocument.pl?360406';
+        td.appendChild(anchor);
+        tr.appendChild(td);
+        tbody.appendChild(tr);
+        table.appendChild(tbody);
+        main_div.appendChild(table);
+        document.body.appendChild(main_div);
+        document.querySelector = jasmine.createSpy('querySelector').and.callFake(() => {
+          return table;
         });
       });
 
-      afterEach(function(){
+      afterEach(function () {
         document.querySelector = jasmine.createSpy('querySelector').and.callThrough();
-      })
-    
-      it('returns the case id', function() {
+      });
+
+      it('returns the case id', function () {
         expect(PACER.getCaseIdFromIQuerySummary()).toBe('360406');
-      })
-
+      });
     });
-    
-    describe('for documents which have not matching format', function(){
 
-      beforeEach(function() {
-        let main_div = InputContainer()
-        let table = document.createElement('table')
-        main_div.appendChild(table)
-        document.body.appendChild(main_div)
-        document.querySelector = jasmine.createSpy('querySelector').and.callFake(()=>{
-          return table
+    describe('for documents which have not matching format', function () {
+      beforeEach(function () {
+        let main_div = InputContainer();
+        let table = document.createElement('table');
+        main_div.appendChild(table);
+        document.body.appendChild(main_div);
+        document.querySelector = jasmine.createSpy('querySelector').and.callFake(() => {
+          return table;
         });
       });
 
-      afterEach(function(){
+      afterEach(function () {
         document.querySelector = jasmine.createSpy('querySelector').and.callThrough();
-      })
+      });
 
-      it('returns null', function() {
+      it('returns null', function () {
         expect(PACER.getCaseIdFromIQuerySummary()).toBe(null);
       });
-    })
-  })
+    });
+  });
 
   describe('parseDoDocPostURL', function () {
     it('gets the right values for an example doDoc string', function () {
@@ -635,40 +612,40 @@ describe('The PACER module', function() {
     });
   });
 
-  describe('normalizeDashes', function(){
-    it('can convert dashes nicely', function(){
+  describe('normalizeDashes', function () {
+    it('can convert dashes nicely', function () {
       let tests = {
-          "en dash –": "en dash -",  // En-dash
-          "em dash —": "em dash -",  // Em-dash
-          "dash -": "dash -",  // Regular dash
-      }
+        'en dash –': 'en dash -', // En-dash
+        'em dash —': 'em dash -', // Em-dash
+        'dash -': 'dash -', // Regular dash
+      };
       for (const [key, value] of Object.entries(tests)) {
-        expect(PACER.normalizeDashes(key)).toBe(value)
+        expect(PACER.normalizeDashes(key)).toBe(value);
       }
     });
   });
 
-  describe('makeDocketNumberCore', function(){
-    it('works as expected', function(){
-      let expected = "1201032";
+  describe('makeDocketNumberCore', function () {
+    it('works as expected', function () {
+      let expected = '1201032';
 
-      expect(PACER.makeDocketNumberCore("2:12-cv-01032-JKG-MJL")).toBe(expected);
-      expect(PACER.makeDocketNumberCore("12-cv-01032-JKG-MJL")).toBe(expected)
-      expect(PACER.makeDocketNumberCore("2:12-cv-01032")).toBe(expected)
-      expect(PACER.makeDocketNumberCore("12-cv-01032")).toBe(expected)
+      expect(PACER.makeDocketNumberCore('2:12-cv-01032-JKG-MJL')).toBe(expected);
+      expect(PACER.makeDocketNumberCore('12-cv-01032-JKG-MJL')).toBe(expected);
+      expect(PACER.makeDocketNumberCore('2:12-cv-01032')).toBe(expected);
+      expect(PACER.makeDocketNumberCore('12-cv-01032')).toBe(expected);
 
       // Do we automatically zero-pad short docket numbers?
-      expect(PACER.makeDocketNumberCore("12-cv-1032")).toBe(expected)
+      expect(PACER.makeDocketNumberCore('12-cv-1032')).toBe(expected);
 
       // bankruptcy numbers
-      expect(PACER.makeDocketNumberCore("12-33112")).toBe("12033112")
-      expect(PACER.makeDocketNumberCore("12-00001")).toBe("12000001")
-      expect(PACER.makeDocketNumberCore("12-0001")).toBe("12000001")
-      expect(PACER.makeDocketNumberCore("06-10672-DHW")).toBe("06010672")
+      expect(PACER.makeDocketNumberCore('12-33112')).toBe('12033112');
+      expect(PACER.makeDocketNumberCore('12-00001')).toBe('12000001');
+      expect(PACER.makeDocketNumberCore('12-0001')).toBe('12000001');
+      expect(PACER.makeDocketNumberCore('06-10672-DHW')).toBe('06010672');
 
       // docket_number fields can be null. If so, the core value should be
       // an empty string.
-      expect(PACER.makeDocketNumberCore(null)).toBe("")
-    })
-  })
+      expect(PACER.makeDocketNumberCore(null)).toBe('');
+    });
+  });
 });

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -634,4 +634,41 @@ describe('The PACER module', function() {
       expect(PACER.parseGoDLSFunction(undefined)).toBeNull();
     });
   });
+
+  describe('normalizeDashes', function(){
+    it('can convert dashes nicely', function(){
+      let tests = {
+          "en dash –": "en dash -",  // En-dash
+          "em dash —": "em dash -",  // Em-dash
+          "dash -": "dash -",  // Regular dash
+      }
+      for (const [key, value] of Object.entries(tests)) {
+        expect(PACER.normalizeDashes(key)).toBe(value)
+      }
+    });
+  });
+
+  describe('makeDocketNumberCore', function(){
+    it('works as expected', function(){
+      let expected = "1201032";
+
+      expect(PACER.makeDocketNumberCore("2:12-cv-01032-JKG-MJL")).toBe(expected);
+      expect(PACER.makeDocketNumberCore("12-cv-01032-JKG-MJL")).toBe(expected)
+      expect(PACER.makeDocketNumberCore("2:12-cv-01032")).toBe(expected)
+      expect(PACER.makeDocketNumberCore("12-cv-01032")).toBe(expected)
+
+      // Do we automatically zero-pad short docket numbers?
+      expect(PACER.makeDocketNumberCore("12-cv-1032")).toBe(expected)
+
+      // bankruptcy numbers
+      expect(PACER.makeDocketNumberCore("12-33112")).toBe("12033112")
+      expect(PACER.makeDocketNumberCore("12-00001")).toBe("12000001")
+      expect(PACER.makeDocketNumberCore("12-0001")).toBe("12000001")
+      expect(PACER.makeDocketNumberCore("06-10672-DHW")).toBe("06010672")
+
+      // docket_number fields can be null. If so, the core value should be
+      // an empty string.
+      expect(PACER.makeDocketNumberCore(null)).toBe("")
+    })
+  })
 });

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -99,8 +99,8 @@ describe('The Recap export module', function () {
       expect(jasmine.Ajax.requests.mostRecent().url).toBe(
         'https://www.courtlistener.com/api/rest/v3/dockets/' +
         '?source__in=1%2C3%2C5%2C7%2C9%2C11%2C13%2C15' +
-        '&court=canb&' +
-        'fields=absolute_url%2Cdate_modified'+
+        '&court=canb' +
+        '&fields=absolute_url%2Cdate_modified'+
         '&pacer_case_id=531316');
     });
 

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -95,20 +95,20 @@ describe('The Recap export module', function () {
     it('encodes the court and caseId in the GET params', function () {
       const expectedCourt = 'canb';
       const expectedCaseId = '531316';
-      recap.getAvailabilityForDocket(expectedCourt, expectedCaseId);
+      recap.getAvailabilityForDocket(expectedCourt, expectedCaseId, null);
       expect(jasmine.Ajax.requests.mostRecent().url).toBe(
         'https://www.courtlistener.com/api/rest/v3/dockets/' +
-        '?pacer_case_id=531316' +
-        '&source__in=1%2C3%2C5%2C7%2C9%2C11%2C13%2C15' +
+        '?source__in=1%2C3%2C5%2C7%2C9%2C11%2C13%2C15' +
         '&court=canb&' +
-        'fields=absolute_url%2Cdate_modified');
+        'fields=absolute_url%2Cdate_modified'+
+        '&pacer_case_id=531316');
     });
 
     it('calls the callback with the parsed server response', function () {
       const callback = jasmine.createSpy();
       const expectedCourt = 'canb';
       const expectedCaseNum = '531316';
-      recap.getAvailabilityForDocket(expectedCourt, expectedCaseNum, callback);
+      recap.getAvailabilityForDocket(expectedCourt, expectedCaseNum, null, callback);
       jasmine.Ajax.requests.mostRecent().respondWith({
         "status": 200,
         "contentType": 'application/json',

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -74,33 +74,32 @@ AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
 
     let dataTable = APPELLATE.getTableWithDataFromCaseSelection();
     let anchors = dataTable.querySelectorAll('a');
-    let districtLink = anchors[anchors.length-1]
+    let districtLink = anchors[anchors.length - 1];
     let districtLinkData = APPELLATE.getDatafromDistrictLinkUrl(districtLink.href);
 
     this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, null, (result) => {
-        if (result.count === 1 && result.results) {
-          PACER.removeBanners();
-          
-          const footer = document.querySelector('div.noprint:last-of-type');
-          const div = document.createElement('div');
-          div.classList.add('recap-banner');
-          div.appendChild(recapAlertButton(this.court, this.pacer_case_id, true));
-          footer.before(div);
-
-          const rIcon = APPELLATE.makeRButtonForCases(result.results[0].absolute_url);
-          const appellateLink = anchors[0];
-          rIcon.insertAfter(appellateLink);
-        }else{
-          PACER.handleDocketAvailabilityMessages(result);
-        }
-      }
-    );
-
-    this.recap.getAvailabilityForDocket(districtLinkData.court, null, districtLinkData.docket_number_core, (result)=>{
       if (result.count === 1 && result.results) {
-          const rIcon = APPELLATE.makeRButtonForCases(result.results[0].absolute_url);
-          rIcon.insertAfter(districtLink);
-      }else{
+        PACER.removeBanners();
+
+        const footer = document.querySelector('div.noprint:last-of-type');
+        const div = document.createElement('div');
+        div.classList.add('recap-banner');
+        div.appendChild(recapAlertButton(this.court, this.pacer_case_id, true));
+        footer.before(div);
+
+        const rIcon = APPELLATE.makeRButtonForCases(result.results[0].absolute_url);
+        const appellateLink = anchors[0];
+        rIcon.insertAfter(appellateLink);
+      } else {
+        PACER.handleDocketAvailabilityMessages(result);
+      }
+    });
+
+    this.recap.getAvailabilityForDocket(districtLinkData.court, null, districtLinkData.docket_number_core, (result) => {
+      if (result.count === 1 && result.results) {
+        const rIcon = APPELLATE.makeRButtonForCases(result.results[0].absolute_url);
+        rIcon.insertAfter(districtLink);
+      } else {
         PACER.handleDocketAvailabilityMessages(result);
       }
     });

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -67,21 +67,36 @@ AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
     this.pacer_case_id = APPELLATE.getCaseIdFromCaseSelection();
     await saveCaseIdinTabStorage({ tabId: this.tabId }, this.pacer_case_id);
 
-    this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, (result) => {
-      if (result.count === 0) {
-        console.warn('RECAP: Zero results found for docket lookup.');
-      } else if (result.count > 1) {
-        console.error(`RECAP: More than one result found for docket lookup. Found ${result.count}`);
-      } else {
-        if (result.results) {
+    let dataTable = APPELLATE.getTableWithDataFromCaseSelection();
+    let anchors = dataTable.querySelectorAll('a');
+    let districtLink = anchors[anchors.length-1]
+    let districtLinkData = APPELLATE.getDatafromDistrictLinkUrl(districtLink.href);
+
+    this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, null, (result) => {
+        if (result.count === 1 && result.results) {
           PACER.removeBanners();
+          
           const footer = document.querySelector('div.noprint:last-of-type');
           const div = document.createElement('div');
           div.classList.add('recap-banner');
           div.appendChild(recapAlertButton(this.court, this.pacer_case_id, true));
-          footer.before(recapBanner(result.results[0]));
           footer.before(div);
+
+          const rIcon = APPELLATE.makeRButtonForCases(result.results[0].absolute_url);
+          const appellateLink = anchors[0];
+          rIcon.insertAfter(appellateLink);
+        }else{
+          PACER.handleDocketAvailabilityMessages(result);
         }
+      }
+    );
+
+    this.recap.getAvailabilityForDocket(districtLinkData.court, null, districtLinkData.docket_number_core, (result)=>{
+      if (result.count === 1 && result.results) {
+          const rIcon = APPELLATE.makeRButtonForCases(result.results[0].absolute_url);
+          rIcon.insertAfter(districtLink);
+      }else{
+        PACER.handleDocketAvailabilityMessages(result);
       }
     });
   } else {
@@ -231,7 +246,7 @@ AppellateDelegate.prototype.handleDocketDisplayPage = async function () {
   let button = recapActionsButton(this.court, this.pacer_case_id, false);
   table.after(button);
 
-  this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, (result) => {
+  this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, null, (result) => {
     if (result.count === 0) {
       console.warn('RECAP: Zero results found for docket lookup.');
     } else if (result.count > 1) {

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -137,8 +137,14 @@ let APPELLATE = {
     });
   },
 
-  // Returns caseId from href attribute of Case Query link on the Case Selection Page.
-  getCaseIdFromCaseSelection: () => {
+  getTableWithDataFromCaseSelection: () =>{
+    // Pages in Appellate PACER use three tables to align items in the headers (one for items on 
+    // the right side, one for items on the left side, and one table to wrap the previous ones), so
+    // the 4th table is the one that lists all the cases that match the user's search criteria.
+    //
+    // This method uses the querySelectorAll method to get all the tables on the page and find the
+    // one with data. 
+
     let table = document.querySelectorAll('table');
 
     if (table.length < 3) {
@@ -147,7 +153,15 @@ let APPELLATE = {
       );
       return;
     }
-    let anchor = table[3].querySelectorAll('tr > td > a');
+    return table[3]
+  },
+
+  // Returns caseId from href attribute of Case Query link on the Case Selection Page.
+  getCaseIdFromCaseSelection: function () {
+    let dataTable = this.getTableWithDataFromCaseSelection()
+    if (!dataTable) return;
+
+    let anchor = dataTable.querySelectorAll('a');
 
     if (anchor.length < 3) {
       console.info(
@@ -155,6 +169,7 @@ let APPELLATE = {
       );
       return;
     }
+
     let queryString = anchor[1].href.split('?')[1];
     let queryParameters = new URLSearchParams(queryString);
     let caseId = queryParameters.get('caseid') || queryParameters.get('caseId');

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -262,4 +262,22 @@ let APPELLATE = {
     }
     return r;
   },
+
+  // Returns an object with the court Id and docket number core extracted from a link to district court
+  getDatafromDistrictLinkUrl: (url) =>{
+    let court = PACER.getCourtFromUrl(url)
+
+    let queryString = url.split('?')[1];
+    let queryParameters = new URLSearchParams(queryString);
+    let docketNumber = queryParameters.get('caseNumber') || queryParameters.get('casenumber');
+
+    if (docketNumber){
+      docketNumber = PACER.makeDocketNumberCore(docketNumber)
+    }
+
+    return { 
+      court: court, 
+      docket_number_core: docketNumber
+    }
+  },
 };

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -280,4 +280,25 @@ let APPELLATE = {
       docket_number_core: docketNumber
     }
   },
+
+  // returns div element that contains an anchor with the RECAP icon
+  makeRButtonForCases: (url)=>{
+    let href = `https://www.courtlistener.com${url}`;
+    let recap_link = $('<a/>', {
+      title: 'Docket is available for free in the RECAP Archive.',
+      href: href,
+      target: '_blank'
+    });
+    recap_link.append(
+      $('<img/>').attr({
+        src: chrome.extension.getURL('assets/images/icon-16.png'),
+      })
+    );
+    let recap_div = $('<div>', {
+      class: 'recap-inline-appellate',
+    });
+    recap_div.append(recap_link);
+    
+    return recap_div;
+  }
 };

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -265,6 +265,17 @@ let APPELLATE = {
 
   // Returns an object with the court Id and docket number core extracted from a link to district court
   getDatafromDistrictLinkUrl: (url) =>{
+    // Converts links to district courts like:
+    //
+    //   https://ecf.dcd.uscourts.gov/cgi-bin/iquery.pl?caseNumber=1:16-cv-00745-ESH
+    //
+    // into:
+    //
+    // {
+    //   court: 'dcd',
+    //   docket_number_core: 1600745
+    // }
+
     let court = PACER.getCourtFromUrl(url)
 
     let queryString = url.split('?')[1];

--- a/src/content.js
+++ b/src/content.js
@@ -14,7 +14,7 @@ let links = document.body.getElementsByTagName('a');
 
 // seed the content_delegate with the tabId by using the message
 // returned from the background worker
-function addRecapInformation(msg) {
+async function addRecapInformation(msg) {
   // destructure the msg object to get the tabId
   const { tabId } = msg;
 
@@ -48,6 +48,9 @@ function addRecapInformation(msg) {
   } else {
     let content_delegate = new ContentDelegate(tabId, url, path, court, pacer_case_id, pacer_doc_id, links);
 
+    // Checks links on the page to get and store the pacer_doc_id and pacer_case_id found in document links.
+    await content_delegate.findAndStorePacerDocIds();
+    
     // If this is a blank iquery or manage my account page, add RECAP Email advertisement banner.
     content_delegate.addRecapEmailAdvertisement();
 

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -202,7 +202,7 @@ ContentDelegate.prototype.handleDocketQueryUrl = function () {
     return;
   }
   
-  this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, (result) => {
+  this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, null, (result) => {
     if (result.count === 0) {
       console.warn('RECAP: Zero results found for docket lookup.');
     } else if (result.count > 1) {

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -31,8 +31,6 @@ let ContentDelegate = function (tabId, url, path, court, pacer_case_id, pacer_do
   this.notifier = importInstance(Notifier);
   this.recap = importInstance(Recap);
 
-  this.findAndStorePacerDocIds();
-
   this.restricted = this.checkRestrictions();
 };
 
@@ -212,7 +210,7 @@ ContentDelegate.prototype.handleDocketQueryUrl = function () {
     return;
   }
 
-  this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, (result) => {
+  this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, null, (result) => {
     if (result.count === 0) {
       console.warn('RECAP: Zero results found for docket lookup.');
     } else if (result.count > 1) {
@@ -276,7 +274,7 @@ ContentDelegate.prototype.handleDocketDisplayPage = async function () {
     tableBody.insertBefore(tr, tableBody.childNodes[0]);
   }
 
-  this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, (result) => {
+  this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, null, (result) => {
     if (result.count === 0) {
       console.warn('RECAP: Zero results found for docket lookup.');
     } else if (result.count > 1) {

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -84,6 +84,53 @@ let PACER = {
       return match[0].slice(1);
     }
   },
+
+  normalizeDashes: (text) =>{
+    // Convert en & em dash(es) to hyphen(s)
+    let normal_dash = "-";
+    let en_dash = "–";
+    let em_dash = "—";
+    let hyphen = "‐";
+    let non_breaking_hyphen = "‑";
+    let figure_dash = "‒";
+    let horizontal_bar = "―";
+    return text.replace(
+        new RegExp(`[${en_dash}${em_dash}${hyphen}${non_breaking_hyphen}${figure_dash}${horizontal_bar}]+`),
+        normal_dash);
+  },
+
+  makeDocketNumberCore: function(docket_number){
+    // Make a core docket number from an existing docket number.
+    //
+    // Converts docket numbers like:
+    //
+    //    2:12-cv-01032
+    //    12-cv-01032
+    //    12-332
+    //
+    // Into:
+    //
+    //    1201032 
+
+    if (!docket_number){
+      return "";
+    }
+
+    docket_number = this.normalizeDashes(docket_number);
+
+    district_m = docket_number.match(/(?:\d:)?(\d\d)-..-(\d+)/);
+    if (district_m){
+      return `${district_m[1]}${district_m[2].padStart(5,0)}`;
+    }
+        
+    bankr_m = docket_number.match(/(\d\d)-(\d+)/);
+    if (bankr_m){
+      //Pad to six characters because some courts have a LOT of bankruptcies
+      return `${bankr_m[1]}${bankr_m[2].padStart(6,0)}`;
+    }
+
+    return "";
+  },
   
   // Returns true if the URL is for docket query page.
   isDocketQueryUrl: function (url) {
@@ -531,6 +578,15 @@ let PACER = {
             <div class='full-page-iframe'>
             <iframe src="${url}" width="100%" height="100%" frameborder="0"></iframe>
             </div>`;
+  },
+
+
+  handleDocketAvailabilityMessages: (result) =>{
+    if (result.count === 0) {
+      console.warn('RECAP: Zero results found for docket lookup.');
+    } else if (result.count > 1) {
+      console.error(`RECAP: More than one result found for docket lookup. Found ${result.count}`);
+    }
   },
 
   // These are all the supported PACER court identifiers, together with their


### PR DESCRIPTION
this PR resolves https://github.com/freelawproject/recap/issues/21.

This PR includes the following changes:

- This PR adds two new helper methods to make **core docket numbers**. The first helper converts en & em dashes to hyphens, and it's called `normalizeDashes`, the other method makes a **core docket number** from an existing docket number, and it's called `makeDocketNumberCore`. This PR also adds tests for these methods.

- A new parameter is added to the getAvailabilityForDocket method. This new parameter is called core_docket_number and allows us to filter dockets using the `pacer_case_id `or the `docket_number_core`.

- This PR removes the `findAndStorePacerDocIds` method from the ContentDelegate class constructor. This method is asynchronous, so we should wait until it finds the doc links on the page, but we cannot use the await operator inside a constructor. This PR also updates all the invocations of the `getAvailabilityForDocket` in this class.

- Three helper functions are added to the Appellate utils.
    - `getTableWithDataFromCaseSelection`: We move some code from the `getCaseIdFromCaseSelection` method into this helper function. This function returns the table with data from the **Case Selection Page** if it's available.
    - `getDatafromDistrictLinkUrl`: this helper extracts the **court id** and the **docket number** from links to the district court available on the Case Selection Page. This utility function also computes the **core docket number**.
    - `makeRButtonForCases`: This function creates a div element that contains an anchor with the link to the district case in the RECAP archive and the RECAP icon.

- This PR moves some checks from the function that handles the response of the `getAvailabilityForDocket` method into a new helper called `handleDocketAvailabilityMessages`.

- This PR updates the `handleCaseSelectionPage` method from the `AppellateDelegate` to inject [R] icons next to the two links on the page. One [R] for the appellate case, and one for the district case ( I used the approach you suggested [here](https://github.com/freelawproject/recap-chrome/pull/296#issuecomment-1366848529)). Here's a gif with that shows the new feature:

![Appellate-district-link](https://user-images.githubusercontent.com/55959657/210090505-cb946c72-6a71-4a72-8dec-557e7c454b01.gif)

### Additional comments

- The response from the `getAvailabilityForDocket` might contain more than one result, in such cases the extension doesn't insert the [R] icon. Here's a gif showing this case:

![Appellate-district-link-error](https://user-images.githubusercontent.com/55959657/210092328-5467e98a-c96b-4d0f-9d62-f84b1d44115b.gif)
