### PR TITLE
feat(options): Add review links to the last tab of the Extension

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -28,7 +28,7 @@
           <a id="nav-donate-tab" class="col-sm text-center nav-item nav-link"
           data-toggle="tab" role="tab" href="#nav-donate"
           aria-controls="nav-donate" aria-selected="false">
-            Donate
+            Help RECAP
           </a>
         </div>
       </nav>
@@ -136,19 +136,40 @@
                 <form method="GET" action="https://www.courtlistener.com/donate/#how-much-donate" target="_blank">
                   <input type="hidden" name="referrer" value="recap-extension" />
                   <input type="hidden" name="amount" value="other">
-                  <div class="input-group mb-3">
+                  <div class="input-group mb-3"> 
                     <div class="input-group-prepend">
                       <span class="input-group-text" id="basic-addon1">$</span>
                     </div>
-                    <input type="text" name="amount_other" placeholder="Amount (min $5)" class="form-control" id="id_amount_other" />
-                  </div>
-
-                  <div id="donate-button-wrapper">
-                    <button type="submit" class="center btn btn-primary" id="donate-button">
-                      <i class="fa fa-heart"></i>&nbsp;Donate
-                    </button>
+                    <input type="number" name="amount_other" placeholder="Amount (Suggested $50)" class="form-control" id="id_amount_other"/>
+                    <div class="input-group-append">
+                      <div id="donate-button-wrapper">
+                        <button type="submit" class="center btn btn-primary" id="donate-button">
+                          <i class="fa fa-heart"></i>&nbsp;Donate
+                        </button>
+                      </div>
+                    </div>
                   </div>
                 </form>
+
+                <h2>Review RECAP</h2>
+                
+                <div class="mt-2">
+                  <p>If you have a minute, please review RECAP using the link below. Your feedback helps us promote RECAP and improve our products.</p>
+                </div>
+                <div class="d-flex justify-content-around">
+                  <a href="https://chrome.google.com/webstore/detail/recap/oiillickanjlaeghobeeknbddaonmjnc/" target="_blank" 
+                    rel="noopener" class="btn btn-primary hidden" role="button" id="chrome_store_button">
+                    Chrome Web Store
+                  </a>
+                  <a href="https://addons.mozilla.org/en-US/firefox/addon/recap-195534/" target="_blank" 
+                    rel="noopener" class="btn btn-primary hidden" role="button" id="firefox_store_button">
+                    Firefox Add-Ons
+                  </a>
+                  <a href="https://apps.apple.com/us/app/recap/id1600281788/" target="_blank" 
+                    rel="noopener" class="btn btn-primary hidden" role="button" id="safari_store_button">
+                    Apple App Store
+                  </a>
+                </div>
               </div>
             </div>
           </div>

--- a/src/options.js
+++ b/src/options.js
@@ -67,6 +67,24 @@ if (navigator.userAgent.indexOf('Chrome') < 0) {
   external_pdf.classList.remove('hidden');
 }
 
+if (/Firefox/.test(navigator.userAgent) && !/Seamonkey/.test(navigator.userAgent)){
+  // Detect firefox engine 
+  let firefox_button = document.getElementById('firefox_store_button')
+  firefox_button.classList.remove('hidden')
+}
+
+if (/Safari/.test(navigator.userAgent) && !/Chrome|Chromium/.test(navigator.userAgent)){
+  // Detect Safari engine 
+  let safari_button = document.getElementById('safari_store_button')
+  safari_button.classList.remove('hidden')
+}
+
+if (/Chrome|Edg./.test(navigator.userAgent) && !/Chromium/.test(navigator.userAgent)){
+  // Detect Chrome engine 
+  let chrome_button = document.getElementById('chrome_store_button')
+  chrome_button.classList.remove('hidden')
+}
+
 load_options();
 handle_storage_changes();
 for (let i = 0; i < inputs.length; i++) {


### PR DESCRIPTION
This PR adds review links to the last tab of the extension and resolves https://github.com/freelawproject/recap/issues/286.

This PR includes the following changes:

- This PR changes the name of the last tab in the extension Popup from **"Donate"** to **"Help RECAP"**.

- The donate button is aligned with the amount input.

- A new section is added in the last tab. This new section asks users for reviews and includes a link to the web store. This PR adds some code to detect the browser name and shows a different link depending on which browser is being used.

### Additional comments

- The extension will use the link to the **Chrome Web Store** in **Microsoft Edge**.

Here's a picture of the tab in different browsers 



**Google Chrome - version 108.0.5359.125**
<img src="https://user-images.githubusercontent.com/55959657/210445918-7f3234fe-45b0-41f9-bbfb-69ebf86f92cf.png" width="450">

**Firefox - 108.0.1 (64-bit)**
      
<img src="https://user-images.githubusercontent.com/55959657/210446306-47819568-467e-4d58-b223-c21a2865aa4f.png" width="450">

**Microsoft Edge - version 108.0.1462.54**
<img src="https://user-images.githubusercontent.com/55959657/210445565-9226d8b5-03fa-4cfa-b075-a99b6d628074.png" width="450"> 

