### PR TITLE
feat(appellate): Upload free documents Apellate PACER

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,7 @@ Features:
  - Add support to upload documents from appellate courts ([#316](https://github.com/freelawproject/recap/issues/316), [#296](https://github.com/freelawproject/recap-chrome/pull/296) ).
  - Add banners to advertise RECAP Email in appellate courts ([#313](https://github.com/freelawproject/recap/issues/313), [#295](https://github.com/freelawproject/recap-chrome/pull/295)).
  - Add links to review RECAP in the extension Popup ([#286](https://github.com/freelawproject/recap/issues/286), [#303](https://github.com/freelawproject/recap-chrome/pull/303))
+ - Upload free documents from Appellate PACER ([#322](https://github.com/freelawproject/recap/issues/322), [#305](https://github.com/freelawproject/recap-chrome/pull/305))
 
 Changes:
  - None yet

--- a/spec/AppellateSpec.js
+++ b/spec/AppellateSpec.js
@@ -141,7 +141,7 @@ describe('The Appellate module', function () {
 
   describe('findDocLinksFromAnchors', function () {
     it('returns empty array for empty input', function () {
-      let {links, } = APPELLATE.findDocLinksFromAnchors([]);
+      let {links, } = APPELLATE.findDocLinksFromAnchors([], '3', new URLSearchParams('docNum=30'));
       expect(links.length).toBe(0);
     });
 
@@ -166,7 +166,7 @@ describe('The Appellate module', function () {
 
         it('returns empty array', function () {
           let anchors = document.querySelectorAll('#no_links > a');
-          let { links, _ } = APPELLATE.findDocLinksFromAnchors(anchors);
+          let { links, _ } = APPELLATE.findDocLinksFromAnchors(anchors,'3', new URLSearchParams('docNum=30'));
           expect(links.length).toBe(0);
         });
       });
@@ -191,7 +191,7 @@ describe('The Appellate module', function () {
 
         it('returns array with doc_ids', function () {
           let anchors = document.querySelectorAll('#links > a');
-          let { links, _ } = APPELLATE.findDocLinksFromAnchors(anchors);
+          let { links, _ } = APPELLATE.findDocLinksFromAnchors(anchors, '3', new URLSearchParams('docNum=30'));
           expect(links.length).toBe(2);
           expect(links).toEqual(['009031927529', '009031956734']);
         });

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -648,4 +648,84 @@ describe('The PACER module', function () {
       expect(PACER.makeDocketNumberCore(null)).toBe('');
     });
   });
+
+  describe('cleanDocLinkNumber', function () {
+    it('can remove whitespace nicely', function () {
+      let tests = {
+        ' 89 ': '89',
+        '&nbsp;89&nbsp;': '89',
+        ' &nbsp; 89 &nbsp; ': '89',
+        ' &nbsp;89&nbsp; ': '89',
+        '&nbsp; 89 &nbsp;': '89',
+        ' 89': '89',
+        '89 ': '89',
+      };
+      for (const [key, value] of Object.entries(tests)) {
+        expect(PACER.cleanDocLinkNumber(key)).toBe(value);
+      }
+    });
+  });
+
+  describe('getDocNumberFromAnchor', function () {
+    it('can get number as expected', function () {
+      let anchor = document.createElement('a');
+      anchor.innerHTML = '&nbsp;89&nbsp;';
+      expect(PACER.getDocNumberFromAnchor(anchor)).toBe('89');
+    });
+
+    it('returns null if the anchor shows an image', function () {
+      let anchor = document.createElement('a');
+      let img = document.createElement('img');
+      anchor.appendChild(img);
+      expect(PACER.getDocNumberFromAnchor(anchor)).toBeNull();
+    });
+  });
+
+  describe('getAttachmentNumberFromAnchor', function () {
+    it('returns 0 if the table has less than four columns', function () {
+      let tr = document.createElement('tr');
+      let anchor_td = document.createElement('td');
+      let anchor = document.createElement('a');
+      anchor_td.appendChild(anchor);
+      tr.appendChild(document.createElement('td'));
+      tr.appendChild(anchor_td);
+      tr.appendChild(document.createElement('td'));
+      expect(PACER.getAttachmentNumberFromAnchor(anchor)).toBe(0);
+    });
+
+    it('returns the attachment number if the table uses checkboxes', function () {
+      let tr = document.createElement('tr');
+
+      let number_td = document.createElement('td');
+      number_td.innerHTML = '5';
+
+      let anchor_td = document.createElement('td');
+      let anchor = document.createElement('a');
+      anchor_td.appendChild(anchor);
+
+      tr.appendChild(document.createElement('td'));
+      tr.appendChild(number_td);
+      tr.appendChild(anchor_td);
+      tr.appendChild(document.createElement('td'));
+      tr.appendChild(document.createElement('td'));
+      expect(PACER.getAttachmentNumberFromAnchor(anchor)).toBe('5');
+    });
+
+    it('returns the attachment number if the table does not have checkboxes', function () {
+      let tr = document.createElement('tr');
+
+      let number_td = document.createElement('td');
+      number_td.innerHTML = '4';
+
+      let anchor_td = document.createElement('td');
+      let anchor = document.createElement('a');
+      anchor_td.appendChild(anchor);
+
+      tr.appendChild(number_td);
+      tr.appendChild(anchor_td);
+      tr.appendChild(document.createElement('td'));
+      tr.appendChild(document.createElement('td'));
+      expect(PACER.getAttachmentNumberFromAnchor(anchor)).toBe('4');
+    });
+  });
 });

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -74,8 +74,7 @@ AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
 
     let dataTable = APPELLATE.getTableWithDataFromCaseSelection();
     let anchors = dataTable.querySelectorAll('a');
-    let districtLink = anchors[anchors.length - 1];
-    let districtLinkData = APPELLATE.getDatafromDistrictLinkUrl(districtLink.href);
+    
 
     this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, null, (result) => {
       if (result.count === 1 && result.results) {
@@ -95,14 +94,18 @@ AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
       }
     });
 
-    this.recap.getAvailabilityForDocket(districtLinkData.court, null, districtLinkData.docket_number_core, (result) => {
-      if (result.count === 1 && result.results) {
-        const rIcon = APPELLATE.makeRButtonForCases(result.results[0].absolute_url);
-        rIcon.insertAfter(districtLink);
-      } else {
-        PACER.handleDocketAvailabilityMessages(result);
-      }
-    });
+    if (anchors.length == 3){
+      let districtLink = anchors[anchors.length - 1];
+      let districtLinkData = APPELLATE.getDatafromDistrictLinkUrl(districtLink.href);
+      this.recap.getAvailabilityForDocket(districtLinkData.court, null, districtLinkData.docket_number_core, (result) => {
+        if (result.count === 1 && result.results) {
+          const rIcon = APPELLATE.makeRButtonForCases(result.results[0].absolute_url);
+          rIcon.insertAfter(districtLink);
+        } else {
+          PACER.handleDocketAvailabilityMessages(result);
+        }
+      });
+    }
   } else {
     // Add the pacer_case_id to each docket link to use it in the docket report
     APPELLATE.addCaseIdToDocketSummaryLink();
@@ -170,7 +173,7 @@ AppellateDelegate.prototype.attachRecapLinksToEligibleDocs = async function () {
   }
 
   // filter the links for the documents available on the page
-  let { links, docsToCases } = APPELLATE.findDocLinksFromAnchors(this.links);
+  let { links, docsToCases } = APPELLATE.findDocLinksFromAnchors(this.links, this.tabId, this.queryParameters);
 
   this.pacer_case_id = this.pacer_case_id
     ? this.pacer_case_id

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -239,8 +239,10 @@ let APPELLATE = {
       let docId = PACER.getDocumentIdFromUrl(clonedNode.href)
       let attNumber = PACER.getAttachmentNumberFromAnchor(clonedNode);
       clonedNode.setAttribute('data-pacer_doc_id', docId);
-      clonedNode.setAttribute('data-pacer_dls_id', doDoc.doc_id);
-      clonedNode.setAttribute('data-pacer_case_id', doDoc.case_id || queryParameters.get('caseId'));
+      if (doDoc && doDoc.doc_id){
+        clonedNode.setAttribute('data-pacer_dls_id', doDoc.doc_id);
+      }
+      clonedNode.setAttribute('data-pacer_case_id', (doDoc && doDoc.case_id) || queryParameters.get('caseId'));
       clonedNode.setAttribute('data-pacer_tab_id', tabId);
       clonedNode.setAttribute('data-document_number', docNum ? docNum : docId);
       clonedNode.setAttribute('data-attachment_number', attNumber);

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -284,7 +284,7 @@ let APPELLATE = {
     //  - doc_number
     //  - att_number
 
-    let dataFromAttachment = /^Document: PDF Document \(Case: ([^']*), Document: (\d)-(\d)\)/.exec(title_string);
+    let dataFromAttachment = /^Document: PDF Document \(Case: ([^']*), Document: (\d+)-(\d+)\)/.exec(title_string);
     let dataFromSingleDoc = /^Document: PDF Document \(Case: ([^']*), Document: (\d+)\)/.exec(title_string);
     if (!dataFromAttachment && !dataFromSingleDoc) {
       return null;

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -163,7 +163,7 @@ let APPELLATE = {
 
     let anchor = dataTable.querySelectorAll('a');
 
-    if (anchor.length < 3) {
+    if (anchor.length < 2) {
       console.info(
         "RECAP: no matching format was detected. There aren't enough anchors in the table that the extension found."
       );
@@ -177,42 +177,75 @@ let APPELLATE = {
     return caseId;
   },
 
+  onClickEventHandler: function (e) {
+    let target = e.currentTarget || e.srcElement;
+    let params = {
+      dls_id: target.dataset.pacer_dls_id,
+      caseId: target.dataset.pacer_case_id,
+      servlet: 'ShowDoc',
+      dktType: 'dktPublic',
+    };
+    let query_string = new URLSearchParams(params).toString();
+    httpRequest(
+      'TransportRoom',
+      query_string,
+      'application/x-www-form-urlencoded',
+      function (type, ab, xhr) {
+        let requestHandler = handleFreeDocResponse.bind(this);
+        requestHandler(type, ab, xhr);
+      }.bind(target)
+    );
+  },
+
   // Create a list of doc_ids from the list of all links available on the page
-  findDocLinksFromAnchors: (nodeList) => {
+  findDocLinksFromAnchors: function (nodeList, tabId, queryParameters) {
     let links = [];
     let docsToCases = {};
     Array.from(nodeList).map((a) => {
       if (!PACER.isDocumentUrl(a.href)) return;
 
+      let docNum = PACER.getDocNumberFromAnchor(a) || queryParameters.get('docNum');
       let doDoc = PACER.parseDoDocPostURL(a.getAttribute('onclick'));
       if (doDoc && doDoc.doc_id && doDoc.case_id) {
         docsToCases[doDoc.doc_id] = doDoc.case_id;
       }
-      
+
       a.removeAttribute('onclick');
       a.setAttribute('target', '_self');
 
-      if(doDoc && doDoc.case_id){
-        let href = a.getAttribute('href')
-        a.setAttribute('href', `${href}?caseId=${doDoc.case_id}`)
+      let url = new URL(a.href);
+      if (doDoc && doDoc.case_id) {
+        url.searchParams.set('caseId', doDoc.case_id);
       }
+
+      if (docNum) {
+        url.searchParams.set('docNum', docNum);
+      }
+
+      a.setAttribute('href', url.toString());
 
       // clone and replace anchor elements to remove all listeners
       let clonedNode = a.cloneNode(true);
       a.replaceWith(clonedNode);
 
       // add a new listener that allows the anchors to target the active tab
-      clonedNode.addEventListener('click', (event) => {
-        let form = document.getElementsByName('doDocPostURLForm')[0];
-        if (form) {
-          form.dls_id.value = params.doc_id;
-          form.caseId.value = params.case_id;
-          form.submit();
-        }
-      });
+      clonedNode.onclick = function (e) {
+        document.body.style.cursor = 'wait'
+        this.onClickEventHandler(e);
+        return false;
+      }.bind(this);
 
-      let docId = PACER.getDocumentIdFromUrl(a.href);
+      // store extra information on anchors to use it while handling the onClick listener
+      let docId = PACER.getDocumentIdFromUrl(clonedNode.href)
+      let attNumber = PACER.getAttachmentNumberFromAnchor(clonedNode);
       clonedNode.setAttribute('data-pacer_doc_id', docId);
+      clonedNode.setAttribute('data-pacer_dls_id', doDoc.doc_id);
+      clonedNode.setAttribute('data-pacer_case_id', doDoc.case_id || queryParameters.get('caseId'));
+      clonedNode.setAttribute('data-pacer_tab_id', tabId);
+      clonedNode.setAttribute('data-document_number', docNum ? docNum : docId);
+      clonedNode.setAttribute('data-attachment_number', attNumber);
+
+      
       links.push(docId);
     });
     return { links, docsToCases };

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -177,7 +177,7 @@ let APPELLATE = {
     return caseId;
   },
 
-  onClickEventHandler: function (e) {
+  onClickEventHandlerForDocLinks: function (e) {
     let target = e.currentTarget || e.srcElement;
     let params = {
       dls_id: target.dataset.pacer_dls_id,
@@ -228,10 +228,11 @@ let APPELLATE = {
       let clonedNode = a.cloneNode(true);
       a.replaceWith(clonedNode);
 
-      // add a new listener that allows the anchors to target the active tab
+      // add a new listener that allows us to request the document data to PACER
+      // and check the response content-type. 
       clonedNode.onclick = function (e) {
         document.body.style.cursor = 'wait'
-        this.onClickEventHandler(e);
+        this.onClickEventHandlerForDocLinks(e);
         return false;
       }.bind(this);
 

--- a/src/background.js
+++ b/src/background.js
@@ -88,6 +88,25 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.message === 'requestTabId') {
     sendResponse({ tabId: sender.tab.id });
   }
+  if (msg.message === 'upload'){
+    let recap = new Recap();
+    let notifier = new Notifier();
+    let callback = function(ok){
+      if (ok) {
+        notifier.showUpload('Free PDF uploaded to the public RECAP Archive.', () => {});
+      }
+    }
+    callback.tab = sender.tab
+    let options = msg.options
+    recap.uploadDocument(
+      options.court,
+      options.pacer_case_id,
+      options.pacer_doc_id,
+      options.document_number,
+      options.attachment_number, 
+      callback
+    )
+  }
 });
 
 chrome.runtime.onInstalled.addListener(setDefaultOptions);

--- a/src/pdf_upload.js
+++ b/src/pdf_upload.js
@@ -131,6 +131,25 @@ const handleDocFormResponse = function (type, ab, xhr, previousPageHtml, dataFro
   }
 };
 
+handleFreeDocResponse = async function (type, ab, xhr) {
+  if (type === 'application/pdf') {
+    let blob = new Blob([new Uint8Array(ab)], { type: type });
+    let dataUrl = await blobToDataURL(blob);
+    await updateTabStorage({ [this.dataset.pacer_tab_id]: { ['pdf_blob']: dataUrl } });
+    // get data attributes through the dataset object  
+    let options = {
+      court: PACER.getCourtFromUrl(window.location.href),
+      pacer_doc_id: this.dataset.pacer_doc_id,
+      pacer_case_id: this.dataset.pacer_case_id,
+      document_number: this.dataset.document_number,
+      attachment_number: this.dataset.attachment_number,
+    };
+    await chrome.runtime.sendMessage({ message: 'upload', type: 'doc', options });
+  }
+
+  window.location.href = this.href;
+};
+
 const showAndUploadPdf = async function (
   html_elements,
   previousPageHtml,
@@ -138,7 +157,7 @@ const showAndUploadPdf = async function (
   attachment_number,
   docket_number,
   pacer_doc_id,
-  restricted = false 
+  restricted = false
 ) {
   // Find the <iframe> URL in the HTML string.
   let match = html_elements.match(/([^]*?)<iframe[^>]*src="(.*?)"([^]*)/);

--- a/src/utils.js
+++ b/src/utils.js
@@ -191,7 +191,7 @@ const updateTabStorage = async object => {
   const updatedVars = object[tabId];
   const store = await getItemsFromStorage(tabId);
   // keep store immutable
-  saveItemToStorage({ [tabId]: { ...store, ...updatedVars } });
+  await saveItemToStorage({ [tabId]: { ...store, ...updatedVars } });
 };
 
 // Save case_id in the chrome local storage

--- a/src/utils.js
+++ b/src/utils.js
@@ -191,7 +191,7 @@ const updateTabStorage = async object => {
   const updatedVars = object[tabId];
   const store = await getItemsFromStorage(tabId);
   // keep store immutable
-  await saveItemToStorage({ [tabId]: { ...store, ...updatedVars } });
+  saveItemToStorage({ [tabId]: { ...store, ...updatedVars } });
 };
 
 // Save case_id in the chrome local storage


### PR DESCRIPTION
This PR adds support to upload free documents from Appellate PACER. This PR resolves https://github.com/freelawproject/recap/issues/322.

This PR introduces the following changes:

 - This PR adds three helper methods to get data related to document links:
     - `getDocNumberFromAnchor`: This helper method gets the **document number** from the anchor element that has a document link.
     - `getAttachmentNumberFromAnchor`: This utility function accesses the row that contains the document link and gets the **attachment number**.
     - `cleanDocLinkNumber`: this helper function removes whitespace from the **document number** and the **attachment number**.
 
- The `findDocLinksFromAnchors` helper method from the `appellate utils` is updated to add an `onClick` event to every document link. This event allows us to check if a **document link** redirects to a free document or to a **download confirmation page**.

- This commit also adds a few [data attributes](https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes) to the anchor elements that have a document link ( `document number`, `attachment number`, `pacer_doc_id`, `case_id`). We need these data attributes to create the data object we send the API when the extension uploads files. 

- A new method called `onClickEventHandler` is added in the `appellate utils` file. This utility will make the findDocLinksFromAnchors method shorter and more readable.

- A new helper function called `handleFreeDocResponse` is added to the `pdf_upload.js` file. This helper checks the `content-type` header of the response. If the `content-type` is `application/pdf`, the extension gets the PDF file as a BLOB and starts the uploading process.

- We need the `document number` to upload files from **attachment pages** but this value is not on the page, so this PR adds this value as a parameter called `docNum` in the query string of each link.

- A new message is added to the background script to upload the free documents.

This approach to upload free documents works in the docket reports and the attachment page. Here's a gif showing the new feature:

![Appellate-free-doc-attachment](https://user-images.githubusercontent.com/55959657/210837992-c66d9615-7147-43dc-b121-c6944baf9c48.gif)


### Additional comment 

- This PR also adds a check in the `case selection page` handler to avoid errors when the district court link is not available on the page. The current implementation of the extension fails to handle **case selection pages** if they don't have a district court link like docket [19-15077](https://www.courtlistener.com/docket/66680340/karastan-edwards-v-us-attorney-general/). Here's a screenshot of this case:

![image](https://user-images.githubusercontent.com/55959657/210837364-ca5c9169-5ca3-4dfa-8c04-f399b49b54ad.png)

The table shows the **originating case number** but there isn't an anchor element that links to the district court. 