### PR TITLE
fix(appellate): Refresh link not working in Appellate pages

### DIFF
--- a/src/action_button.js
+++ b/src/action_button.js
@@ -72,6 +72,20 @@ const recapDropdownMenu = (court, pacerCaseId) => {
   checkDoc.setAttribute('id', 'refresh-recap-links');
   checkDoc.setAttribute('role', 'button');
 
+  checkDoc.addEventListener('click', () => {
+    let links = document.querySelectorAll('.recap-inline, .recap-inline-appellate');
+    links.forEach((link) => {
+      link.remove();
+    });
+    let spinner = document.getElementById('recap-button-spinner');
+    if (spinner) {
+      spinner.classList.remove('recap-btn-spinner-hidden');
+    }
+    getTabIdForContentScript().then((msg) => {
+      addRecapInformation(msg);
+    });
+  });
+
   checkLi.appendChild(checkDoc);
   dropdownWrapper.appendChild(checkLi);
 

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -247,8 +247,11 @@ AppellateDelegate.prototype.handleDocketDisplayPage = async function () {
 
   // Query the first table with case data and insert the RECAP actions button
   let table = document.querySelectorAll('table')[3];
-  let button = recapActionsButton(this.court, this.pacer_case_id, false);
-  table.after(button);
+  const existingActionButton = document.getElementById('recap-action-button');
+  if (!existingActionButton) {
+    let button = recapActionsButton(this.court, this.pacer_case_id, false);
+    table.after(button);
+  }
 
   this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, null, (result) => {
     if (result.count === 0) {

--- a/src/content.js
+++ b/src/content.js
@@ -19,7 +19,6 @@ async function addRecapInformation(msg) {
   const { tabId } = msg;
 
   if (PACER.isLoginPage(url)) {
-    
     let redactionConfirmation = document.getElementById('redactionConfirmation');
     let emailInput = document.getElementById('loginForm:loginName');
     let passwordInput = document.getElementById('loginForm:password');
@@ -49,7 +48,7 @@ async function addRecapInformation(msg) {
 
     // Checks links on the page to get and store the pacer_doc_id and pacer_case_id found in document links.
     await content_delegate.findAndStorePacerDocIds();
-    
+
     // If this is a blank iquery or manage my account page, add RECAP Email advertisement banner.
     content_delegate.addRecapEmailAdvertisement();
 
@@ -109,27 +108,6 @@ function handleRedactionConfirmation(mutationRecords) {
   });
 }
 
-// Callback function to execute when the RECAP actions button
-// is inserted in the docket display page
-function handleRecapActionButtonInsertion(mutationRecords) {
-  let recapRefreshButton = document.getElementById('refresh-recap-links');
-  if (recapRefreshButton) {
-    recapRefreshButton.addEventListener('click', () => {
-      let links = document.querySelectorAll('.recap-inline');
-      links.forEach((link) => {
-        link.remove();
-      });
-      let spinner = document.getElementById('recap-button-spinner');
-      if (spinner) {
-        spinner.classList.remove('recap-btn-spinner-hidden');
-      }
-      getTabIdForContentScript().then((msg) => {
-        addRecapInformation(msg);
-      });
-    });
-  }
-}
-
 // Query relevant inputs in the page.
 let caseNumberInput = document.getElementById('case_number_text_area_0');
 let allCaseInput = document.getElementById('all_case_ids');
@@ -151,27 +129,6 @@ if (caseNumberInput) {
   // Add listener to the search bar
   caseNumberInput.addEventListener('input', () => {
     PACER.removeBanners();
-  });
-}
-
-// if the content script found a tbody element on the page, It would create an
-// observer to watch for insertions/removal of a child inside that HTML tag.
-//
-// This operation(insertion/removal) is relevant because the "RECAP actions" button
-// is inserted inside a tbody tag some time after the js files from the extension
-// are loaded, so it's not possible to query or add a listener to this button right
-// from the start.
-//
-// this mutation will help the extension know when a new element is inserted in the
-// tbody tag and the callback function will check if this new element is the "RECAP
-// actions" button.
-if (tableBody) {
-  // create a mutation observer to watch for changes being made to
-  // the childlist of the table element
-  const observer = new MutationObserver((mutationRecords) => handleRecapActionButtonInsertion(mutationRecords));
-  observer.observe(tableBody, {
-    subtree: false,
-    childList: true,
   });
 }
 


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/recap/issues/328

This PR introduces the following changes:

- This PR removes the mutation observer that allows us to watch for changes made to the childlist of the table element. This approach to add an `onClick` event to the **Recap Actions** button works only for district court pages. The mutation observer fails in Appellate pages because the HTML structure is different and the **RECAP actions** button is inserted in a different table.

- This PR adds an `onClick` event to the **Refresh links** button right after the extension creates it. The event handler removes the RECAP icons, shows the spinner, and invokes the `addRecapInformation` method. This new approach fixes the Refresh button for appellate pages because the extension is not relying on the mutation observer to add the onClick event.

- We add checks in the appellate class to avoid duplicating the RECAP actions button.

Here are some gifs of the refresh link button working in **District** and **Appellate** courts:

**Appellate PACER**

![refresh-links-appellate](https://user-images.githubusercontent.com/55959657/211108511-963be8cf-eac0-4d81-85d1-c4e7756fea40.gif)


**District PACER**

![refresh-links-district](https://user-images.githubusercontent.com/55959657/211108776-cd760b99-1545-4e4a-bf0b-370e82e484cf.gif)
