### PR TITLE
fix(attachment page): Add missing attachment number in Appellate

### DIFF
--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -370,8 +370,8 @@ AppellateDelegate.prototype.onDocumentViewSubmit = function (event) {
   let title = document.querySelectorAll('strong')[1].innerHTML;
   let dataFromTitle = APPELLATE.parseReceiptPageTitle(title);
 
-  if (dataFromTitle.att_number == 0 && this.queryParameters.get('attNum')){
-    dataFromTitle.att_number = this.queryParameters.get('attNum')
+  if (dataFromTitle.att_number == 0 && this.queryParameters.get('recapAttNum')){
+    dataFromTitle.att_number = this.queryParameters.get('recapAttNum')
   }
 
   if (!dataFromTitle) {

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -369,6 +369,11 @@ AppellateDelegate.prototype.onDocumentViewSubmit = function (event) {
 
   let title = document.querySelectorAll('strong')[1].innerHTML;
   let dataFromTitle = APPELLATE.parseReceiptPageTitle(title);
+
+  if (dataFromTitle.att_number == 0 && this.queryParameters.get('attNum')){
+    dataFromTitle.att_number = this.queryParameters.get('attNum')
+  }
+
   if (!dataFromTitle) {
     form.submit();
     return;

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -214,12 +214,16 @@ let APPELLATE = {
       a.setAttribute('target', '_self');
 
       let url = new URL(a.href);
-      if (doDoc && doDoc.case_id) {
-        url.searchParams.set('caseId', doDoc.case_id);
-      }
+      url.searchParams.set('caseId', (doDoc && doDoc.case_id) || queryParameters.get('caseId'));
 
       if (docNum) {
         url.searchParams.set('docNum', docNum);
+      }
+
+      // if an attachment number is found, it adds it to the link href
+      let attNumber = PACER.getAttachmentNumberFromAnchor(a);
+      if (attNumber != 0) {
+        url.searchParams.set('attNum', attNumber);
       }
 
       a.setAttribute('href', url.toString());
@@ -229,18 +233,18 @@ let APPELLATE = {
       a.replaceWith(clonedNode);
 
       // add a new listener that allows us to request the document data to PACER
-      // and check the response content-type. 
+      // and check the response content-type.
       clonedNode.onclick = function (e) {
-        document.body.style.cursor = 'wait'
+        document.body.style.cursor = 'wait';
         this.onClickEventHandlerForDocLinks(e);
         return false;
       }.bind(this);
 
       // store extra information on anchors to use it while handling the onClick listener
-      let docId = PACER.getDocumentIdFromUrl(clonedNode.href)
-      let attNumber = PACER.getAttachmentNumberFromAnchor(clonedNode);
+      let docId = PACER.getDocumentIdFromUrl(clonedNode.href);
+
       clonedNode.setAttribute('data-pacer_doc_id', docId);
-      if (doDoc && doDoc.doc_id){
+      if (doDoc && doDoc.doc_id) {
         clonedNode.setAttribute('data-pacer_dls_id', doDoc.doc_id);
       }
       clonedNode.setAttribute('data-pacer_case_id', (doDoc && doDoc.case_id) || queryParameters.get('caseId'));
@@ -248,7 +252,6 @@ let APPELLATE = {
       clonedNode.setAttribute('data-document_number', docNum ? docNum : docId);
       clonedNode.setAttribute('data-attachment_number', attNumber);
 
-      
       links.push(docId);
     });
     return { links, docsToCases };
@@ -294,7 +297,7 @@ let APPELLATE = {
       [, r.docket_number, r.doc_number, r.att_number] = dataFromAttachment;
     } else {
       [, r.docket_number, r.doc_number] = dataFromSingleDoc;
-      r.att_num = 0;
+      r.att_number = 0;
     }
     return r;
   },

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -24,7 +24,11 @@ let APPELLATE = {
   //   - Check the storage
   getCaseId: async (tabId, queryParameters, docId) => {
     let input = document.querySelector('input[name=caseId]');
-    let pacer_case_id = queryParameters.get('caseid') || queryParameters.get('caseId') || (input && input.value);
+    let pacer_case_id =
+      queryParameters.get('recapCaseId') ||
+      queryParameters.get('caseid') ||
+      queryParameters.get('caseId') ||
+      (input && input.value);
 
     // try to get a mapping from a pacer_doc_id in the URL to the pacer_case_id
     if (!pacer_case_id && docId) {
@@ -204,7 +208,7 @@ let APPELLATE = {
     Array.from(nodeList).map((a) => {
       if (!PACER.isDocumentUrl(a.href)) return;
 
-      let docNum = PACER.getDocNumberFromAnchor(a) || queryParameters.get('docNum');
+      let docNum = PACER.getDocNumberFromAnchor(a) || queryParameters.get('recapDocNum');
       let doDoc = PACER.parseDoDocPostURL(a.getAttribute('onclick'));
       if (doDoc && doDoc.doc_id && doDoc.case_id) {
         docsToCases[doDoc.doc_id] = doDoc.case_id;
@@ -214,16 +218,17 @@ let APPELLATE = {
       a.setAttribute('target', '_self');
 
       let url = new URL(a.href);
-      url.searchParams.set('caseId', (doDoc && doDoc.case_id) || queryParameters.get('caseId'));
+      let pacerCaseId = (doDoc && doDoc.case_id) || queryParameters.get('recapCaseId') || queryParameters.get('caseId');
+      url.searchParams.set('recapCaseId', pacerCaseId);
 
       if (docNum) {
-        url.searchParams.set('docNum', docNum);
+        url.searchParams.set('recapDocNum', docNum);
       }
 
       // if an attachment number is found, it adds it to the link href
       let attNumber = PACER.getAttachmentNumberFromAnchor(a);
       if (attNumber != 0) {
-        url.searchParams.set('attNum', attNumber);
+        url.searchParams.set('recapAttNum', attNumber);
       }
 
       a.setAttribute('href', url.toString());
@@ -247,7 +252,7 @@ let APPELLATE = {
       if (doDoc && doDoc.doc_id) {
         clonedNode.setAttribute('data-pacer_dls_id', doDoc.doc_id);
       }
-      clonedNode.setAttribute('data-pacer_case_id', (doDoc && doDoc.case_id) || queryParameters.get('caseId'));
+      clonedNode.setAttribute('data-pacer_case_id', pacerCaseId);
       clonedNode.setAttribute('data-pacer_tab_id', tabId);
       clonedNode.setAttribute('data-document_number', docNum ? docNum : docId);
       clonedNode.setAttribute('data-attachment_number', attNumber);

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -638,7 +638,18 @@ let PACER = {
     //   - The document Link
     //   - A description 
     //   - The number of pages
+    //
+    //  Each row of the docket report has the following information:
+    //
+    //   - filed date
+    //   - docket entry number
+    //   - A description
     //    
+    //  We can use the number of elements per row to group the possible cases:
+    //
+    //  - Rows with 3 or less elements belong to a docket report. 
+    //  - Rows with four or five elements belong to an attachment menu.
+    //
     //  This method accesses the tr element that contains the document link, checks the number
     //  of elements inside this tag (we want to exclude rows from docket reports) and returns the 
     //  attachment number of the document.

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -644,7 +644,7 @@ let PACER = {
     //  attachment number of the document.
 
     let row = anchor.parentNode.parentNode;
-    if (row.childElementCount < 3) {
+    if (row.childElementCount <= 3) {
       // Attachment menu pages should have more than 3 element per row.
       return 0;
     }


### PR DESCRIPTION
This PR resolves https://github.com/freelawproject/recap/issues/327.

This PR includes the following changes:

- This PR will update the if statement in the `getAttachmentNumberFromAnchor` method to avoid looking for an attachment number if the row has 3 or fewer children nodes. The current implementation uses the `<` which fails if the row that contains the doc links has exactly 3 children nodes ( The table from the docket report has exactly 3 data cell elements but we don't want to search the attachment number in that table).

- This PR adds the `attachment number` to the doc links URL if it's found on the page and also makes sure that the `caseId `is always added to the href attribute.

- We add a new if statement to check the queryparameters


