### PR TITLE
feat(district): Add button to autofill docket query form

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Features:
  - Add banners to advertise RECAP Email in appellate courts ([#313](https://github.com/freelawproject/recap/issues/313), [#295](https://github.com/freelawproject/recap-chrome/pull/295)).
  - Add links to review RECAP in the extension Popup ([#286](https://github.com/freelawproject/recap/issues/286), [#303](https://github.com/freelawproject/recap-chrome/pull/303))
  - Upload free documents from Appellate PACER ([#322](https://github.com/freelawproject/recap/issues/322), [#305](https://github.com/freelawproject/recap-chrome/pull/305))
+ - Add button to autofill docket query form in district courts ([#311](https://github.com/freelawproject/recap-chrome/pull/311), [#190](https://github.com/freelawproject/recap/issues/190))
 
 Changes:
  - None yet

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -12,8 +12,8 @@ describe('The ContentDelegate class', function () {
         set: jasmine.createSpy('set').and.callFake(function () {}),
         remove: jasmine.createSpy('remove').and.callFake(() => {}),
       },
-    }
-  }
+    },
+  };
 
   // 'path' values
   const districtCourtURI = 'https://ecf.canb.uscourts.gov';
@@ -232,8 +232,15 @@ describe('The ContentDelegate class', function () {
     beforeEach(function () {
       clearDocumentBody();
       form = document.createElement('form');
+
+      dateToField = document.createElement('input');
+      dateToField.setAttribute('name', 'date_to');
+      document.body.appendChild(dateToField);
+
       document.body.appendChild(form);
-      document.querySelector = jasmine.createSpy('querySelector').and.callFake((id) => (id != 'form' ? null : form));
+      document.querySelector = jasmine
+        .createSpy('querySelector')
+        .and.callFake((id) => (document.querySelectorAll(id).length ? document.querySelectorAll(id)[0] : null));
     });
 
     afterEach(function () {
@@ -268,10 +275,12 @@ describe('The ContentDelegate class', function () {
         status: 200,
         contentType: 'application/json',
         responseText:
-          '{"count": 1, "results": [' +
-          '{"date_modified": "04/16/15", "absolute_url": ' +
-          '"/download/gov.uscourts.' +
-          'canb.531591/gov.uscourts.canb.531591.docket.html"}]}',
+          '{"count": 1,' +
+          '"results": [{' +
+          '"date_modified": "04/16/15",' +
+          '"absolute_url": "/download/gov.uscourts.canb.531591/gov.uscourts.canb.531591.docket.html",' +
+          '"date_last_filing": "2015-04-20"' +
+          '}]}',
       });
       const banner = document.querySelectorAll('.recap-banner')[0];
       expect(banner).not.toBeNull();
@@ -1075,9 +1084,9 @@ describe('The ContentDelegate class', function () {
         // });
       });
 
-      afterEach(function(){
-        window.getPacerCaseIdFromPacerDocId = jasmine.createSpy().and.callThrough()
-      })
+      afterEach(function () {
+        window.getPacerCaseIdFromPacerDocId = jasmine.createSpy().and.callThrough();
+      });
 
       it('makes the back button redisplay the previous page', async function () {
         await cd.showPdfPage(html);

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -290,6 +290,28 @@ describe('The ContentDelegate class', function () {
       expect(link.href).toBe(
         'https://www.courtlistener.com/download/gov.uscourts.' + 'canb.531591/gov.uscourts.canb.531591.docket.html'
       );
+      const autofill = document.querySelector('.recap-filing-button');
+      expect(autofill).not.toBeNull();
+    });
+
+    it("don't inserts the autofill button when a docket don't have last_filing", function () {
+      const cd = docketQueryContentDelegate;
+      spyOn(PACER, 'hasPacerCookie').and.returnValue(true);
+      cd.handleDocketQueryUrl();
+      jasmine.Ajax.requests.mostRecent().respondWith({
+        status: 200,
+        contentType: 'application/json',
+        responseText: '{"count": 1,' +
+        '"results": [{' +
+        '"date_modified": "04/16/15",' +
+        '"absolute_url": "/download/gov.uscourts.canb.531591/gov.uscourts.canb.531591.docket.html",' +
+        '"date_last_filing": null' +
+        '}]}',
+      });
+      const banner = document.querySelectorAll('.recap-banner')[0];
+      expect(banner).not.toBeNull();
+      const autofill = document.querySelector('.recap-filing-button');
+      expect(autofill).toBeNull();
     });
 
     it('has no effect when on a docket query that has no RECAP', function () {

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -100,7 +100,7 @@ describe('The Recap export module', function () {
         'https://www.courtlistener.com/api/rest/v3/dockets/' +
         '?source__in=1%2C3%2C5%2C7%2C9%2C11%2C13%2C15' +
         '&court=canb' +
-        '&fields=absolute_url%2Cdate_modified'+
+        '&fields=absolute_url%2Cdate_modified%2Cdate_last_filing'+
         '&pacer_case_id=531316');
     });
 

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -498,3 +498,12 @@ footer #version {
   display: inline-flex;
   padding: 0px 3px;
 }
+
+.recap-filing-button{
+  vertical-align: middle;
+  padding-left: 4px;
+}
+
+.recap-filing-button > img{
+  padding-top: 2px;
+}

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -210,12 +210,16 @@ ContentDelegate.prototype.handleDocketQueryUrl = function () {
     } else {
       if (result.results) {
         PACER.removeBanners();
+        const dateToInput = document.querySelector('input[name=date_to]');
         const form = document.querySelector('form');
         const div = document.createElement('div');
+        
         div.classList.add('recap-banner');
         div.appendChild(recapAlertButton(this.court, this.pacer_case_id, true));
         form.appendChild(recapBanner(result.results[0]));
         form.appendChild(div);
+
+        dateToInput.after(recapAddLatestFilingButton(result.results[0]));
       }
     }
   });

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -219,7 +219,7 @@ ContentDelegate.prototype.handleDocketQueryUrl = function () {
         form.appendChild(recapBanner(result.results[0]));
         form.appendChild(div);
 
-        dateToInput.after(recapAddLatestFilingButton(result.results[0]));
+        if (result.results[0].date_last_filing) dateToInput.after(recapAddLatestFilingButton(result.results[0]));
       }
     }
   });

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -181,7 +181,7 @@ let PACER = {
 
   // Remove banners inserted by the extension
   removeBanners: ()=>{
-    let banners = document.querySelectorAll('.recap-banner');
+    let banners = document.querySelectorAll('.recap-banner, .recap-filing-button');
     banners.forEach(banner => { banner.remove(); });
   },
 

--- a/src/recap.js
+++ b/src/recap.js
@@ -33,7 +33,7 @@ function Recap() {
         // Ensure RECAP is a source so we don't get back IDB-only dockets.
         source__in: '1,3,5,7,9,11,13,15',
         court: PACER.convertToCourtListenerCourt(pacer_court),
-        fields: 'absolute_url,date_modified'
+        fields: 'absolute_url,date_modified,date_last_filing'
       }
 
       if (pacer_case_id){

--- a/src/utils.js
+++ b/src/utils.js
@@ -215,6 +215,11 @@ const removeFilingState = () => {
   document.cookie = "isFilingAccount=false;path=/;domain=.uscourts.gov";
 }
 
+//takes a date in 'YYYY-MM-DD' format returns it in 'MM/DD/YYYY' format
+function pacerDateFormat(date) {
+  return date.replace(/(\d+)-(\d+)-(\d+)/, "$2/$3/$1");
+}
+
 // Default settings for any jquery $.ajax call.
 $.ajaxSetup({
   // The dataType parameter is a security measure requested by Opera code
@@ -283,7 +288,39 @@ const recapAlertButton = (court, pacerCaseId, isActive) => {
   return anchor;
 };
 
+// Creates an anchor element to autofill the Docket Query form
+const recapAddLatestFilingButton = (result) =>{
+  
+  let date = result.date_last_filing
+  let formatted_date = pacerDateFormat(date)
 
+  const anchor = document.createElement('a');
+  anchor.classList.add("recap-filing-button");
+  anchor.title = 'This will purchase filings since the latest we have on RECAP, omitting parties and member cases.'
+  anchor.setAttribute('data-date_from', formatted_date);
+  anchor.href = '#'
+
+  const img = document.createElement('img');
+  img.src = chrome.extension.getURL('assets/images/icon-16.png');
+
+  anchor.innerHTML =`${img.outerHTML}`
+
+  anchor.onclick = function (e) {
+    let target = e.currentTarget || e.target;
+
+    let dateInput = document.querySelector("[name='date_from']");
+    let partyCheckbox = document.getElementById("list_of_parties_and_counsel");
+    let filedCheckbox = document.querySelector('input[value="Filed"]');
+
+    dateInput.value = target.dataset.date_from
+    partyCheckbox.checked = false
+    filedCheckbox.checked = true
+    
+    return false
+  }
+
+  return anchor;
+}
 
 // Creates a div element to show a docket is available for free  
 const recapBanner = (result) => {

--- a/src/utils.js
+++ b/src/utils.js
@@ -289,38 +289,37 @@ const recapAlertButton = (court, pacerCaseId, isActive) => {
 };
 
 // Creates an anchor element to autofill the Docket Query form
-const recapAddLatestFilingButton = (result) =>{
-  
-  let date = result.date_last_filing
+const recapAddLatestFilingButton = (result) => {
+  let date = result.date_last_filing;
   let formatted_date = pacerDateFormat(date)
 
   const anchor = document.createElement('a');
-  anchor.classList.add("recap-filing-button");
-  anchor.title = 'This will purchase filings since the latest we have on RECAP, omitting parties and member cases.'
+  anchor.classList.add('recap-filing-button');
+  anchor.title = 'This will purchase filings since the latest we have on RECAP, omitting parties and member cases.';
   anchor.setAttribute('data-date_from', formatted_date);
-  anchor.href = '#'
+  anchor.href = '#';
 
   const img = document.createElement('img');
   img.src = chrome.extension.getURL('assets/images/icon-16.png');
 
-  anchor.innerHTML =`${img.outerHTML}`
+  anchor.innerHTML = `${img.outerHTML}`;
 
   anchor.onclick = function (e) {
     let target = e.currentTarget || e.target;
 
     let dateInput = document.querySelector("[name='date_from']");
-    let partyCheckbox = document.getElementById("list_of_parties_and_counsel");
+    let partyCheckbox = document.getElementById('list_of_parties_and_counsel');
     let filedCheckbox = document.querySelector('input[value="Filed"]');
 
-    dateInput.value = target.dataset.date_from
-    partyCheckbox.checked = false
-    filedCheckbox.checked = true
-    
-    return false
-  }
+    dateInput.value = target.dataset.date_from;
+    partyCheckbox.checked = false;
+    filedCheckbox.checked = true;
+
+    return false;
+  };
 
   return anchor;
-}
+};
 
 // Creates a div element to show a docket is available for free  
 const recapBanner = (result) => {


### PR DESCRIPTION
This PR resolves https://github.com/freelawproject/recap/issues/190.

This PR introduces the following changes:

- A new field is added to the `getAvailabilityForDocket` request. This PR adds the `date_last_filing` field to the list of dynamically selected fields.

- This PR adds two helper functions in the utils.js file. 

    - `pacerDateFormat`: takes a date and returns it in 'MM/DD/YYYY' format
    - `recapAddLatestFilingButton`: creates the HTML button that is inserted on the page and also creates an onClick event listener for this object. This utility function uses the `date_last_filing` from the response of `getAvailabilityForDocket` request to create a data attribute in the button.

- This PR adds CSS classes to change the styling of the new button.

- The helper method called `removeBanners` is updated to also remove the new button. 

- This PR adds the helper method `recapAddLatestFilingButton` to the Docket Query handler to create the filing button next to the date input field of the form.

Here's a gif showing the feature:

![refresh-button-district](https://user-images.githubusercontent.com/55959657/211598032-34ce22a2-fc8d-490c-b0d1-1af611aec911.gif)
