### PR TITLE
fix(appellate utils): Remove namespace of the caseId parameter

### DIFF
--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -25,7 +25,6 @@ let APPELLATE = {
   getCaseId: async (tabId, queryParameters, docId) => {
     let input = document.querySelector('input[name=caseId]');
     let pacer_case_id =
-      queryParameters.get('recapCaseId') ||
       queryParameters.get('caseid') ||
       queryParameters.get('caseId') ||
       (input && input.value);
@@ -218,8 +217,8 @@ let APPELLATE = {
       a.setAttribute('target', '_self');
 
       let url = new URL(a.href);
-      let pacerCaseId = (doDoc && doDoc.case_id) || queryParameters.get('recapCaseId') || queryParameters.get('caseId');
-      url.searchParams.set('recapCaseId', pacerCaseId);
+      let pacerCaseId = (doDoc && doDoc.case_id) || queryParameters.get('caseId');
+      url.searchParams.set('caseId', pacerCaseId);
 
       if (docNum) {
         url.searchParams.set('recapDocNum', docNum);


### PR DESCRIPTION
This PR removes the namespace we added in [#308](https://github.com/freelawproject/recap-chrome/pull/308) to the `caseId` parameter. 

We should avoid changing this parameter name because **PACER** is using it to get more information about the **docket entry** associated with the document, We added this parameter to fix https://github.com/freelawproject/recap/issues/324.