### PR TITLE
fix(appellate): Avoid uploading case summary with the wrong case_id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@ Changes:
  - None yet
 
 Fixes:
- - None yet
- - 
+ - More robust uploading of case summary pages from appellate ([#330](https://github.com/freelawproject/recap/issues/330))
+  
 For developers:
  - Nothing yet
 

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -403,6 +403,20 @@ describe('The ContentDelegate class', function () {
           tbody.appendChild(tr);
           table.appendChild(tbody);
           document.body.appendChild(table);
+          window.chrome = {
+            extension: { getURL: jasmine.createSpy('gerURL') },
+            storage: {
+              local: {
+                get: jasmine.createSpy().and.callFake((_, cb) => {
+                  cb({
+                    [1234]: { caseId: '531591' },
+                    options: { recap_enabled: true },
+                  });
+                }),
+                set: jasmine.createSpy('set').and.callFake(function () {}),
+              },
+            },
+          };
         });
 
         it('when not on a docket display url', function () {
@@ -430,6 +444,20 @@ describe('The ContentDelegate class', function () {
           table.appendChild(tbody);
           document.body.appendChild(table);
           history.replaceState({ uploaded: true }, '');
+          window.chrome = {
+            extension: { getURL: jasmine.createSpy('gerURL') },
+            storage: {
+              local: {
+                get: jasmine.createSpy().and.callFake((_, cb) => {
+                  cb({
+                    [1234]: { caseId: '531591' },
+                    options: { recap_enabled: true },
+                  });
+                }),
+                set: jasmine.createSpy('set').and.callFake(function () {}),
+              },
+            },
+          };
         });
 
         afterEach(function () {
@@ -463,6 +491,20 @@ describe('The ContentDelegate class', function () {
           document.body.appendChild(input);
           document.body.appendChild(input2);
           document.body.appendChild(table);
+          window.chrome = {
+            extension: { getURL: jasmine.createSpy('gerURL') },
+            storage: {
+              local: {
+                get: jasmine.createSpy().and.callFake((_, cb) => {
+                  cb({
+                    [1234]: { caseId: '531591' },
+                    options: { recap_enabled: true },
+                  });
+                }),
+                set: jasmine.createSpy('set').and.callFake(function () {}),
+              },
+            },
+          };
         });
 
         it('does not call uploadDocket', async function () {

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -60,9 +60,9 @@ let APPELLATE = {
     let docketNumber =
       queryParameters.get('casenum') ||
       queryParameters.get('caseNum') ||
-      queryParameters.get('recapCaseNum') ||
       (csNum1Input && csNum1Input.value) ||
-      (caseNumInput && caseNumInput.value);
+      (caseNumInput && caseNumInput.value) ||
+      queryParameters.get('recapCaseNum');
 
     return docketNumber;
   },


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/recap/issues/330.

This PR introduces the following changes:

-  This commit adds a new helper function called `getDocketNumber`. This new helper uses different approaches to get the docket number from the appellate pages.

- A new URL query parameter is added to the anchor's href attribute. This new query parameter is called `recapCaseNum`. This new parameter will be used as the last resource to get the docket number from an appellate page.

- This PR updates the methods `handleCaseSelectionPage`, `handleCaseQueryPage`, `attachRecapLinksToEligibleDocs`, `handleDocketDisplayPage` and `handleSingleDocumentPageView` from the AppellateDelegate class to save the docket number to the tab storage.

- Update the helper method called `getCaseId` to check the docket number of the appellate page before using the `pacer_case_id` saved in the local storage.