### PR TITLE
Fix broken icon in iOS

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
  - None yet
 
 Fixes:
- - Nothing yet
+ - Support for Safari on macOS and iPhone([#332](https://github.com/freelawproject/recap/issues/332)).
 
 For developers:
  - Nothing yet

--- a/safari/build-safari.py
+++ b/safari/build-safari.py
@@ -1,4 +1,3 @@
-import glob
 import json
 import os
 import plistlib
@@ -80,38 +79,6 @@ def update_css_and_macOS_html(operating_system: str) -> None:
         shutil.copyfile(src, dst)
 
 
-def update_js_files(operating_system: str):
-    """ Wrap JS files into a function to avoid being called multiple times. 
-
-    Safari injects JS files multiple times generating variables being duplicated
-    so this method wraps the indicated JS files in a method that avoid being 
-    executed multiple times.
-
-    :param operating_system: The OS to update the plist for
-    :return: None
-    """
-    
-    if operating_system == "iOS":
-        path = "iOS/Recap!/Recap! Extension/Resources/assets/js/bootstrap.bundle.js"
-    
-    if operating_system == "macOS":
-        path = "macOS/Recap!/Recap! Extension/Resources/assets/js/bootstrap.bundle.js"
-
-    for file in glob.glob(path):
-        with open(file, 'r+') as f:
-            lines = f.readlines()
-            f.seek(0)
-            line1 = "if (typeof injectedYet === 'undefined') { \n"
-            line2 = "// the script has not been injected, so we can run it  \n"
-            line3 = "var injectedYet = 1; \n\n"
-            f.writelines([line1, line2, line3])
-            for line in lines:
-                f.write(line)
-            line4 = "\n}"
-            f.writelines([line4])
-            f.close()
-
-
 def convert_recap_chrome_to_safari(operating_system: str) -> None:
     """Generate an iOS and macOS version of the extension.
 
@@ -144,10 +111,6 @@ def convert_recap_chrome_to_safari(operating_system: str) -> None:
 
     # Update CSS for iOS
     update_css_and_macOS_html(operating_system)
-
-    # Update JS files for each OS
-    update_js_files(operating_system)
-
 
 if __name__ == "__main__":
     if sys.platform != "darwin":

--- a/safari/build-safari.py
+++ b/safari/build-safari.py
@@ -1,3 +1,4 @@
+import glob
 import json
 import os
 import plistlib
@@ -78,6 +79,39 @@ def update_css_and_macOS_html(operating_system: str) -> None:
         dst = f"macOS/Recap!/Recap!/Base.lproj/Main.html"
         shutil.copyfile(src, dst)
 
+
+def update_js_files(operating_system: str):
+    """ Wrap JS files into a function to avoid being called multiple times. 
+
+    Safari injects JS files multiple times generating variables being duplicated
+    so this method wraps the indicated JS files in a method that avoid being 
+    executed multiple times.
+
+    :param operating_system: The OS to update the plist for
+    :return: None
+    """
+    
+    if operating_system == "iOS":
+        path = "iOS/Recap!/Recap! Extension/Resources/assets/js/bootstrap.bundle.js"
+    
+    if operating_system == "macOS":
+        path = "macOS/Recap!/Recap! Extension/Resources/assets/js/bootstrap.bundle.js"
+
+    for file in glob.glob(path):
+        with open(file, 'r+') as f:
+            lines = f.readlines()
+            f.seek(0)
+            line1 = "if (typeof injectedYet === 'undefined') { \n"
+            line2 = "// the script has not been injected, so we can run it  \n"
+            line3 = "var injectedYet = 1; \n\n"
+            f.writelines([line1, line2, line3])
+            for line in lines:
+                f.write(line)
+            line4 = "\n}"
+            f.writelines([line4])
+            f.close()
+
+
 def convert_recap_chrome_to_safari(operating_system: str) -> None:
     """Generate an iOS and macOS version of the extension.
 
@@ -110,6 +144,9 @@ def convert_recap_chrome_to_safari(operating_system: str) -> None:
 
     # Update CSS for iOS
     update_css_and_macOS_html(operating_system)
+
+    # Update JS files for each OS
+    update_js_files(operating_system)
 
 
 if __name__ == "__main__":

--- a/src/InjectManager.js
+++ b/src/InjectManager.js
@@ -1,0 +1,5 @@
+chrome.runtime.onMessage.addListener(function (request, sender, sendResponse) {
+  if (request.message === 'content_script_status') {
+    sendResponse({ status: 'loaded' });
+  }
+});

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -60,6 +60,10 @@ AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
     // and shows 'CaseSelectionTable.jsp' as its value.
     //
     // This check avoids sending pages like the one previously described to the API.
+    if (!PACER.hasFilingCookie(document.cookie)) {
+      return;
+    }
+
     form = document.querySelector('form');
     if (!document.querySelector('.recap-email-banner-full')) {
       form.appendChild(recapEmailBanner('recap-email-banner-full'));

--- a/src/assets/css/style-ios.css
+++ b/src/assets/css/style-ios.css
@@ -15,6 +15,21 @@
 */
 
 /*
+  CSS to use font files from the assets folder
+*/
+.fa {
+  font-family: 'RecapFontAwesome' !important;
+}
+
+@font-face {
+  font-family: 'RecapFontAwesome';
+  src: url("chrome-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2"), 
+  url("moz-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2");
+  font-weight: normal;
+  font-style: normal;
+}
+
+/*
    CSS For the options page
 */
 #options-body {
@@ -272,3 +287,252 @@ footer #version {
 }
 
 
+.btn-disabled{
+  pointer-events: none !important;
+}
+
+.caret {
+  display: inline-block;
+  width: 0;
+  height: 0;
+  margin-left: 5px;
+  vertical-align: middle;
+  border-top: 4px solid;
+  border-right: 4px solid transparent;
+  border-left: 4px solid transparent;
+}
+
+.btn{
+  display: inline-block;
+  margin-bottom: 0;
+  font-weight: normal;
+  text-align: center;
+  vertical-align: middle;
+  touch-action: manipulation;
+  cursor: pointer;
+  background-image: none;
+  border: 1px solid transparent;
+  white-space: nowrap;
+  padding: 6px 12px;
+  font-size: 12px;
+  line-height: 1.42857143;
+  font-family: Sans-Serif;
+  border-radius: 4px;
+  -webkit-user-select: none;
+  -moz-user-select: none;
+  -ms-user-select: none;
+  user-select: none;
+}
+
+.btn-group{
+  position: relative;
+  display: flex;
+  vertical-align: middle;
+  margin-top: 5px;
+  margin-left: 5px;
+}
+
+.btn-primary {
+  color: #fff;
+  background-color: #428bca;
+  border-color: #357ebd;
+}
+
+.btn-primary:hover,
+.btn-primary:focus,
+.btn-primary.focus,
+.btn-primary:active,
+.btn-primary.active{
+  color: #ffffff;
+  background-color: #3071a9;
+  border-color: #285e8e;
+}
+
+.btn-primary:active,
+.btn-primary.active{
+  background-image: none;
+}
+
+.btn-group>.btn+.dropdown-toggle {
+  padding-left: 8px;
+  padding-right: 8px;
+}
+
+.btn-group>.btn:last-child:not(:first-child), .btn-group>.dropdown-toggle:not(:first-child) {
+  border-bottom-left-radius: 0;
+  border-top-left-radius: 0;
+}
+
+.btn-group .btn+.btn, 
+.btn-group .btn+.btn-group, 
+.btn-group .btn-group+.btn, 
+.btn-group .btn-group+.btn-group {
+  margin-left: -1px;
+}
+
+.btn-group>.btn{
+  position: relative;
+  float: left;
+}
+
+.btn-group>.btn:first-child:not(:last-child):not(.dropdown-toggle) {
+  border-bottom-right-radius: 0;
+  border-top-right-radius: 0;
+}
+
+.btn-group>.btn:first-child {
+  margin-left: 0;
+}
+
+.btn-group>.btn{
+  position: relative;
+  float: left;
+}
+
+.dropdown {
+  position: relative;
+}
+.dropdown-toggle:focus {
+  outline: 0;
+}
+.dropdown-menu {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  z-index: 1000;
+  display: none;
+  float: left;
+  min-width: 160px;
+  padding: 5px 0;
+  margin: 2px 0 0;
+  list-style: none;
+  font-size: 12px;
+  text-align: left;
+  background-color: #ffffff;
+  border: 1px solid #cccccc;
+  border: 1px solid rgba(0, 0, 0, 0.15);
+  border-radius: 4px;
+  -webkit-box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  box-shadow: 0 6px 12px rgba(0, 0, 0, 0.175);
+  background-clip: padding-box;
+}
+.dropdown-menu.pull-right {
+  right: 0;
+  left: auto;
+}
+.dropdown-menu .divider {
+  height: 1px;
+  margin: 7.5px 0;
+  overflow: hidden;
+  background-color: #e5e5e5;
+}
+.dropdown-menu > li > a {
+  display: block;
+  padding: 3px 20px;
+  clear: both;
+  font-weight: normal;
+  line-height: 1.42857143;
+  color: #333333;
+  white-space: nowrap;
+  text-decoration: none;
+  font-family: Sans-Serif;
+}
+.dropdown-menu > li > a:hover,
+.dropdown-menu > li > a:focus {
+  text-decoration: none;
+  color: #262626;
+  background-color: #f5f5f5;
+}
+.dropdown-menu > .active > a,
+.dropdown-menu > .active > a:hover,
+.dropdown-menu > .active > a:focus {
+  color: #ffffff;
+  text-decoration: none;
+  outline: 0;
+  background-color: #428bca;
+}
+.dropdown-menu > .disabled > a,
+.dropdown-menu > .disabled > a:hover,
+.dropdown-menu > .disabled > a:focus {
+  color: #777777;
+}
+.dropdown-menu > .disabled > a:hover,
+.dropdown-menu > .disabled > a:focus {
+  text-decoration: none;
+  background-color: transparent;
+  background-image: none;
+  filter: progid:DXImageTransform.Microsoft.gradient(enabled = false);
+  cursor: not-allowed;
+}
+.open > .dropdown-menu {
+  display: block;
+}
+.open > a {
+  outline: 0;
+}
+
+.open > .dropdown-toggle.btn-primary {
+  background-image: none;
+}
+
+.show {
+  display: block !important;
+}
+
+.dropdown-header {
+  display: block;
+  margin-bottom: 0;
+  margin-top: 0.5rem;
+  margin-bottom: 0.5rem;
+  margin-left: 0.5rem;
+  font-size: 0.75rem;
+  white-space: nowrap;
+  font-family: "Helvetica Neue",Helvetica,Arial,sans-serif;
+}
+
+.recap-dropdown-divider {
+  height: 0;
+  margin: 0.5rem 0;
+  overflow: hidden;
+  border-top: 1px solid rgba(0, 0, 0, 0.175);
+  opacity: 1;
+}
+
+.recap-btn-spinner-hidden{
+  display: none !important;
+}
+
+.full-page-iframe{
+  position: absolute; 
+  left: 0; 
+  right: 0; 
+  bottom: 0; 
+  top: 0; 
+}
+
+.recap-inline-appellate{
+  display: inline-flex;
+  padding: 0px 3px;
+}
+
+.recap-filing-button{
+  vertical-align: middle;
+  padding-left: 4px;
+}
+
+.recap-filing-button > img{
+  padding-top: 2px;
+}
+
+.recap-banner-inner-div{
+  display: inline-flex;
+}
+
+.recap-banner-inner-div > p{
+  margin: 0px;
+  padding: 0px 2px;
+}
+
+.recap-banner-inner-div > img{
+  margin-right: 0.25rem;
+}

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -170,6 +170,10 @@ footer #version {
   color: #aaa;
 }
 
+.d-inline-flex{
+  display: inline-flex !important;
+}
+
 .recap-email-banner-full{
   font-family: helvetica, arial, serif;
   font-size: 13px;
@@ -508,15 +512,11 @@ footer #version {
   padding-top: 2px;
 }
 
-.recap-banner-inner-div{
-  display: inline-flex;
-}
-
-.recap-banner-inner-div > p{
+.banner-message > p {
   margin: 0px;
   padding: 0px 2px;
 }
 
-.recap-banner-inner-div > img{
+.banner-message > img{
   margin-right: 0.25rem;
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -507,3 +507,16 @@ footer #version {
 .recap-filing-button > img{
   padding-top: 2px;
 }
+
+.recap-banner-inner-div{
+  display: inline-flex;
+}
+
+.recap-banner-inner-div > p{
+  margin: 0px;
+  padding: 0px 2px;
+}
+
+.recap-banner-inner-div > img{
+  margin-right: 0.25rem;
+}

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -24,6 +24,7 @@
     "notifications",
     "storage",
     "unlimitedStorage",
+    "activeTab",
     "tabs",
     "cookies"
   ],
@@ -44,24 +45,6 @@
     "css": [
       "assets/css/style.css",
       "assets/css/font-awesome.css"
-    ],
-    "js": [
-      "assets/js/jquery.js",
-      "assets/js/FileSaver.js",
-      "assets/js/moment.js",
-      "assets/js/livestamp.js",
-      "assets/js/bootstrap.bundle.js",
-      "action_button.js",
-      "pdf_upload.js",
-      "utils.js",
-      "notifier.js",
-      "toolbar_button.js",
-      "pacer.js",
-      "recap.js",
-      "content_delegate.js",
-      "appellate/utils.js",
-      "appellate/appellate.js",
-      "content.js"
     ],
     "run_at": "document_end"
   }, {

--- a/src/utils.js
+++ b/src/utils.js
@@ -364,6 +364,9 @@ const recapBanner = (result) => {
   let message = `View and Search this docket as of ${time.outerHTML} for free from RECAP`;
   let innerDiv = makeMessageForBanners(message)
 
+  const small = document.createElement('small');
+  small.innerText = 'Note that archived dockets may be out of date';
+  
   anchor.append(innerDiv)
 
   div.appendChild(anchor);

--- a/src/utils.js
+++ b/src/utils.js
@@ -265,6 +265,24 @@ function debug(level, varargs) {
   }
 }
 
+// Creates a div element with the recap logo and a message
+const makeMessageForBanners = (text) =>{
+  const innerDiv = document.createElement('div');
+  innerDiv.classList.add("d-inline-flex");
+  innerDiv.classList.add("banner-message");
+  
+  const img = document.createElement('img');
+  img.src = chrome.extension.getURL('assets/images/icon-16.png');
+
+  const p = document.createElement('p');
+  p.innerHTML = text;
+
+  innerDiv.appendChild(img);
+  innerDiv.appendChild(p);
+
+  return innerDiv
+}
+
 // inject a "follow this case on RECAP" button
 const recapAlertButton = (court, pacerCaseId, isActive) => {
   const anchor = document.createElement('a');
@@ -286,15 +304,8 @@ const recapAlertButton = (court, pacerCaseId, isActive) => {
   const img = document.createElement('img');
   img.src = chrome.extension.getURL(`assets/images/${icon}-16.png`);
 
-  const p = document.createElement('p')
-  p.innerHTML = text
-  
-  const innerDiv = document.createElement('div')
-  innerDiv.classList.add("recap-banner-inner-div");
-  
-  innerDiv.appendChild(img)
-  innerDiv.appendChild(p)
-
+  let innerDiv = makeMessageForBanners(text)
+ 
   anchor.append(innerDiv)
   
   return anchor;
@@ -344,24 +355,14 @@ const recapBanner = (result) => {
   anchor.title = 'Docket is available for free in the RECAP Archive.';
   anchor.target = '_blank';
   anchor.href = `https://www.courtlistener.com${result.absolute_url}`
-  const img = document.createElement('img');
-  img.src = chrome.extension.getURL('assets/images/icon-16.png');
+  
   const time = document.createElement('time');
   time.setAttribute('data-livestamp', result.date_modified);
   time.setAttribute('title', result.date_modified);
   time.innerHTML = result.date_modified;
-  
-  const p = document.createElement('p')
-  p.innerHTML = `View and Search this docket as of ${time.outerHTML} for free from RECAP`;
 
-  const small = document.createElement('small');
-  small.innerText = 'Note that archived dockets may be out of date';
-
-  const innerDiv = document.createElement('div')
-  innerDiv.classList.add("recap-banner-inner-div");
-
-  innerDiv.appendChild(img)
-  innerDiv.appendChild(p)
+  let message = `View and Search this docket as of ${time.outerHTML} for free from RECAP`;
+  let innerDiv = makeMessageForBanners(message)
 
   anchor.append(innerDiv)
 
@@ -380,17 +381,8 @@ const recapEmailBanner = (css_class = 'recap-email-banner') => {
   anchor.target = '_blank';
   anchor.href = `https://www.courtlistener.com/help/recap/email/`
 
-  const innerDiv = document.createElement('div')
-  innerDiv.classList.add("recap-banner-inner-div");
-
-  const img = document.createElement('img');
-  img.src = chrome.extension.getURL('assets/images/icon-16.png');
-
-  const p = document.createElement('p')
-  p.innerHTML = 'Use @recap.email to automatically contribute all your cases to RECAP.'
-
-  innerDiv.appendChild(img)
-  innerDiv.appendChild(p)
+  let message = 'Use @recap.email to automatically contribute all your cases to RECAP.'
+  let innerDiv = makeMessageForBanners(message)
   
   anchor.appendChild(innerDiv)
   div.appendChild(anchor);

--- a/src/utils.js
+++ b/src/utils.js
@@ -282,9 +282,21 @@ const recapAlertButton = (court, pacerCaseId, isActive) => {
   url.searchParams.append('pacer_case_id', pacerCaseId);
   url.searchParams.append('court_id', court);
   anchor.href = url.toString();
+  
   const img = document.createElement('img');
   img.src = chrome.extension.getURL(`assets/images/${icon}-16.png`);
-  anchor.innerHTML = `${img.outerHTML} ${text}`;
+
+  const p = document.createElement('p')
+  p.innerHTML = text
+  
+  const innerDiv = document.createElement('div')
+  innerDiv.classList.add("recap-banner-inner-div");
+  
+  innerDiv.appendChild(img)
+  innerDiv.appendChild(p)
+
+  anchor.append(innerDiv)
+  
   return anchor;
 };
 
@@ -302,7 +314,7 @@ const recapAddLatestFilingButton = (result) => {
   const img = document.createElement('img');
   img.src = chrome.extension.getURL('assets/images/icon-16.png');
 
-  anchor.innerHTML = `${img.outerHTML}`;
+  anchor.appendChild(img);
 
   anchor.onclick = function (e) {
     let target = e.currentTarget || e.target;
@@ -338,12 +350,20 @@ const recapBanner = (result) => {
   time.setAttribute('data-livestamp', result.date_modified);
   time.setAttribute('title', result.date_modified);
   time.innerHTML = result.date_modified;
-  const anchorHtml = `${img.outerHTML} View and Search this docket as of ${time.outerHTML} for free from RECAP`;
+  
+  const p = document.createElement('p')
+  p.innerHTML = `View and Search this docket as of ${time.outerHTML} for free from RECAP`;
 
   const small = document.createElement('small');
   small.innerText = 'Note that archived dockets may be out of date';
 
-  anchor.innerHTML = anchorHtml;
+  const innerDiv = document.createElement('div')
+  innerDiv.classList.add("recap-banner-inner-div");
+
+  innerDiv.appendChild(img)
+  innerDiv.appendChild(p)
+
+  anchor.append(innerDiv)
 
   div.appendChild(anchor);
   div.appendChild(document.createElement('br'));
@@ -360,10 +380,19 @@ const recapEmailBanner = (css_class = 'recap-email-banner') => {
   anchor.target = '_blank';
   anchor.href = `https://www.courtlistener.com/help/recap/email/`
 
+  const innerDiv = document.createElement('div')
+  innerDiv.classList.add("recap-banner-inner-div");
+
   const img = document.createElement('img');
   img.src = chrome.extension.getURL('assets/images/icon-16.png');
 
-  anchor.innerHTML = `${img.outerHTML} Use @recap.email to automatically contribute all your cases to RECAP.`;
+  const p = document.createElement('p')
+  p.innerHTML = 'Use @recap.email to automatically contribute all your cases to RECAP.'
+
+  innerDiv.appendChild(img)
+  innerDiv.appendChild(p)
+  
+  anchor.appendChild(innerDiv)
   div.appendChild(anchor);
   return div
 }


### PR DESCRIPTION
This PR fixes issues that We found in Safari and resolves https://github.com/freelawproject/recap/issues/332. 

This PR introduces the following changes:

- We use a new approach to create the content of the banners. The current implementation of the extension creates a banner with a broken icon in safari so in order to fix that We're adding a helper function called `makeMessageForBanners`, this utility method creates the content of the banner and returns a `div` element.

- This PR updates the file called `style-ios.css`. This file has all the CSS classes that are used to build the extension that is going to be installed on iPhones.

- We're now injecting the content scripts using the background.js file to avoid **duplication**. This issue seems to be pretty common because Safari injects scripts into the **top-level page** and any **subpages** with HTML sources. The [docs ](https://developer.apple.com/documentation/safariservices/safari_app_extensions/using_injected_style_sheets_and_scripts?language=objc) for Safari extension developers say that we should not assume that there’s only one instance of your script per browser tab. We're making the following changes to accomplish the [programmatically injection](https://developer.chrome.com/docs/extensions/mv2/content_scripts/#programmatic
) of the scripts:

    - We add the [activeTab](https://developer.chrome.com/docs/extensions/mv2/manifest/activeTab/) permission in the manifest.json file
    
    - We're removing all the js files that matches **URLs** containing the string **uscourts.gov** from the `manifest.json` and creating a new list that contains all the files listed in the manifest.json in the background page. This new list is called `CONTENT_SCRIPT_FILES` .
    
    - We're using the **onUpdated** event of the chrome.tabs API to start injecting the js files to the page.
   
    - The background script sends a message to the tab checking if the content scripts are already inserted, if the tab doesn't send a response to the background, It will start injecting the content scripts. We need this extra step before injecting the js files because the onUpdated event is fired several times when a user navigates to a new URL in a Tab and We just want to use the event the first time that's fired. 
