### PR TITLE
Safari release notes and updated build-safari.py

### DIFF
--- a/safari/APPLE.md
+++ b/safari/APPLE.md
@@ -23,7 +23,51 @@ This will create two new directories for iOS (and iPadOS) and macOS.
 Each of these directories will contain a new extension and XCode project.
 
 Once generated you can run the separate xcode projects.  You may need to tweak the bundle 
-identifier, which does not like the bang(!) in the name. 
+identifier. 
 
 Additionally, you may need to select a developer account to install this on your own device(s).
 
+# Release Notes
+
+In order to release a new RECAP Uploader version for Safari, the following tweaks are needed on each Xcode project (iOS and MacOS):
+
+
+- Select "Recap" in the project sidebar, then go to TARGETS and select "Recap", go to the General panel and change the following:
+ App Category: "Productivity"
+ Display Name: "RECAP Uploader"
+ Version: Set the current extension version in manifest.json
+
+- Go to Signing & Capabilities panel, select a Team, and then change the bundler identifier to: free.law.recap
+
+Repeat the process now by selecting "Recap Extension" under TARGETS, in the General panel change:
+- Display Name: "RECAP Uploader Extension"
+- Bundler Identifier: free.law.recap.Extension
+- Version: Set the current extension version in manifest.json
+
+Go to Signing & Capabilities panel, select a Team, and then change the bundler identifier to: free.law.recap.Extension
+
+In order to avoid the "Missing Compliance" status when submiting a build to the App Store Connect,
+is neccesary to add the following key in the info.plist:
+
+- Go to the file "Recap/Recap/Info.plist", right click -> Add row, search and select: App Uses Non-Exempt Encryption and set its value to NO
+
+After these changes are done, you should create a build to submit:
+
+If you're in the iOS project first you need to select "Any iOS Device" in the project bar, then click on the "Product" menu and click "Archive". 
+
+After the build is done, the Archives window appears:
+- Select the Archive and click on "Distribute App"
+- Select App Store Connect and Next
+- Select Upload and Next
+- Keep the following options checked and Next
+- Select Automatically managing signing and Next
+- Finally click on the Upload button.
+
+
+Then in App Store Connect:
+
+- Select RECAP Uploader 
+- Create a new version for iOS and MacOS clicking the + and set a version target.
+- Update the release information like features, version and screenshots.
+- Select the build uploaded in previous steps.
+- Request a Review.

--- a/safari/build-safari.py
+++ b/safari/build-safari.py
@@ -12,7 +12,7 @@ def update_extension_plist(operating_system: str):
     :param operating_system: The OS to update the plist for
     :return: None
     """
-    with open(f"{operating_system}/Recap!/Recap! Extension/Info.plist", "rb") as f:
+    with open(f"{operating_system}/Recap/Recap Extension/Info.plist", "rb") as f:
         p = plistlib.loads(f.read())
     p["NSExtension"]["SFSafariPageProperties"] = {
         "Level": "Some",
@@ -23,7 +23,7 @@ def update_extension_plist(operating_system: str):
             "*.uscourts.gov",
         ],
     }
-    with open(f"{operating_system}/Recap!/Recap! Extension/Info.plist", "wb") as f:
+    with open(f"{operating_system}/Recap/Recap Extension/Info.plist", "wb") as f:
         plistlib.dump(p, fp=f)
 
 
@@ -38,10 +38,10 @@ def update_manifest_files(operating_system: str) -> None:
 
     #This runs XC (Xcode) commandline tool to automate the build and versions numbers.
     os.system(
-        f"cd {operating_system}/Recap! && xcrun agvtool new-version {manifest['version']}"
+        f"cd {operating_system}/Recap && xcrun agvtool new-version {manifest['version']}"
     )
     os.system(
-        f"cd {operating_system}/Recap! && xcrun agvtool new-marketing-version {manifest['version']}"
+        f"cd {operating_system}/Recap && xcrun agvtool new-marketing-version {manifest['version']}"
     )
 
     manifest["permissions"] = [
@@ -57,7 +57,7 @@ def update_manifest_files(operating_system: str) -> None:
         manifest["background"]["persistent"] = False
 
     with open(
-        f"{operating_system}/Recap!/Recap! Extension/Resources/manifest.json", "w"
+        f"{operating_system}/Recap/Recap Extension/Resources/manifest.json", "w"
     ) as f:
         json.dump(manifest, f, indent=2)
 
@@ -69,13 +69,17 @@ def update_css_and_macOS_html(operating_system: str) -> None:
     :return: None
     """
     if operating_system == "iOS":
-        src = f"iOS/Recap!/Recap! Extension/Resources/assets/css/style-ios.css"
-        dst = f"iOS/Recap!/Recap! Extension/Resources/assets/css/style.css"
+        src = f"iOS/Recap/Recap Extension/Resources/assets/css/style-ios.css"
+        dst = f"iOS/Recap/Recap Extension/Resources/assets/css/style.css"
         os.rename(src, dst)
+
+        src = f"resources/recap-iOS.html"
+        dst = f"iOS/Recap/Recap/Base.lproj/Main.html"
+        shutil.copyfile(src, dst)
 
     if operating_system == "macOS":
         src = f"resources/recap-macOS.html"
-        dst = f"macOS/Recap!/Recap!/Base.lproj/Main.html"
+        dst = f"macOS/Recap/Recap/Base.lproj/Main.html"
         shutil.copyfile(src, dst)
 
 
@@ -94,7 +98,7 @@ def convert_recap_chrome_to_safari(operating_system: str) -> None:
     os.system(
         f"xcrun safari-web-extension-converter {os.getcwd()}/../src/ "
         f"--project-location {operating_system}/ "
-        f"--app-name Recap! "
+        f"--app-name Recap "
         f"--bundle-identifier free.law.recap "
         f"--no-open "
         f"--force "

--- a/safari/resources/recap-iOS.html
+++ b/safari/resources/recap-iOS.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+
+    <meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no">
+
+    <link rel="stylesheet" href="../Style.css">
+</head>
+<body>
+    <img src="../Icon.png" width="128" height="128" alt="Recap Icon">
+    <p>You can turn on RECAP Uploader’s Safari extension in Settings.</p>
+</body>
+</html>

--- a/safari/resources/recap-macOS.html
+++ b/safari/resources/recap-macOS.html
@@ -10,13 +10,13 @@
     <script src="../Script.js" defer></script>
 </head>
 <body>
-    <img src="../Icon.png" width="100" height="100" alt="Recap! Icon">
-    <p class="state-unknown">You can turn on Recap!’s extension in Safari Extensions preferences.
+    <img src="../Icon.png" width="100" height="100" alt="RECAP Uploader Icon">
+    <p class="state-unknown">You can turn on RECAP Uploader’s extension in Safari Extensions preferences.
     <br><br>
     Quit this extension and open <br> Safari > Preferences > Extensions
     </p>
-    <p class="state-on">Recap!’s extension is currently on. You can turn it off in Safari Extensions preferences.</p>
-    <p class="state-off">Recap!’s extension is currently off. You can turn it on in Safari Extensions preferences.</p>
+    <p class="state-on">RECAP Uploader’s extension is currently on. You can turn it off in Safari Extensions preferences.</p>
+    <p class="state-off">RECAP Uploader’s extension is currently off. You can turn it on in Safari Extensions preferences.</p>
     <button class="open-preferences">Quit</button>
 </body>
 </html>


### PR DESCRIPTION
I've added the release notes for safari and also updated `build-safari.py` after removing the `!` from the name, also updated the splash screens for ios and mac to match the new app name "RECAP Uploader".

