### PR TITLE
appellate/utils.js: Use URLSearchParams() properly

### DIFF
--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -159,9 +159,9 @@ let APPELLATE = {
       // attribute allow us to get the desired HTML element.
       let caseSummaryAnchor = caseQueryAnchor.parentElement.firstChild;
       // This has the side effect of making this URL absolute, when it may have started out relative.
-      summaryUrl = new URL(window.location, caseSummaryAnchor.href);
+      let summaryUrl = new URL(window.location, caseSummaryAnchor.href);
       summaryUrl.searchParams.set('caseId', caseId);
-      caseSummaryAnchor.setAttribute('href', summaryURL);
+      caseSummaryAnchor.setAttribute('href', summaryUrl);
     });
   },
 

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -151,13 +151,17 @@ let APPELLATE = {
     // us to support Case Selection pages with multiple cases.
 
     document.querySelectorAll('a[href*="caseid"]').forEach((caseQueryAnchor) => {
-      let params = new URLSearchParams(caseQueryAnchor.href);
-      let caseId = params.get('caseId') || params.get('caseid');
+      let queryUrl = new URL(window.location, caseQueryAnchor.href);
+      let queryParams = queryUrl.searchParams;
+      let caseId = queryParams.get('caseId') || queryParams.get('caseid');
       // the Docket Report and the Case Query links are enclosed by the same HTML tag and the anchor for
       // the Docket Report is the first element inside this tag so using the parentElement and the firstChild
       // attribute allow us to get the desired HTML element.
       let caseSummaryAnchor = caseQueryAnchor.parentElement.firstChild;
-      caseSummaryAnchor.setAttribute('href', `${caseSummaryAnchor.href}&caseId=${caseId}`);
+      // This has the side effect of making this URL absolute, when it may have started out relative.
+      summaryUrl = new URL(window.location, caseSummaryAnchor.href);
+      summaryUrl.searchParams.set('caseId', caseId);
+      caseSummaryAnchor.setAttribute('href', summaryURL);
     });
   },
 
@@ -194,8 +198,8 @@ let APPELLATE = {
       return;
     }
 
-    let queryString = anchor[1].href.split('?')[1];
-    let queryParameters = new URLSearchParams(queryString);
+    let url = new URL(window.location, anchor[1].href);
+    let queryParameters = url.searchParams;
     let caseId = queryParameters.get('caseid') || queryParameters.get('caseId');
 
     return caseId;

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -151,7 +151,7 @@ let APPELLATE = {
     // us to support Case Selection pages with multiple cases.
 
     document.querySelectorAll('a[href*="caseid"]').forEach((caseQueryAnchor) => {
-      let queryUrl = new URL(window.location, caseQueryAnchor.href);
+      let queryUrl = new URL(caseQueryAnchor.href, window.location);
       let queryParams = queryUrl.searchParams;
       let caseId = queryParams.get('caseId') || queryParams.get('caseid');
       // the Docket Report and the Case Query links are enclosed by the same HTML tag and the anchor for
@@ -159,7 +159,7 @@ let APPELLATE = {
       // attribute allow us to get the desired HTML element.
       let caseSummaryAnchor = caseQueryAnchor.parentElement.firstChild;
       // This has the side effect of making this URL absolute, when it may have started out relative.
-      let summaryUrl = new URL(window.location, caseSummaryAnchor.href);
+      let summaryUrl = new URL(caseSummaryAnchor.href, window.location);
       summaryUrl.searchParams.set('caseId', caseId);
       caseSummaryAnchor.setAttribute('href', summaryUrl);
     });
@@ -198,7 +198,7 @@ let APPELLATE = {
       return;
     }
 
-    let url = new URL(window.location, anchor[1].href);
+    let url = new URL(anchor[1].href, window.location);
     let queryParameters = url.searchParams;
     let caseId = queryParameters.get('caseid') || queryParameters.get('caseId');
 


### PR DESCRIPTION
CA9 and CA2 both use ACMS for some dockets (**Edit: not just** immigration), which are hosted on an external website with a different URL form. So we have this sort of thing:

<img width="829" alt="Screen Shot 2023-04-19 at 22 42 47" src="https://user-images.githubusercontent.com/1270718/233244694-ae89dcef-4bf6-4eec-8bdf-33a0aea14834.png">

with:

```html
<td>
  <a href="https://ca2-showdoc.azurewebsites.us/23-6359" target="_blank">
    23-6359
  </a>
  <br>
  <a href="TransportRoom?servlet=CaseQuery.jsp&amp;cnthd=2026821867&amp;caseid=1002765&amp;csnum1=23-6359&amp;shorttitle=United+States+of+America+v.+Conde+%28Kone%29">
    United States of America v. Conde (Kone)
  </a>
  &nbsp;
</td>
```

And the current code breaks that first `<a>` link by appending a bare `&caseId` to it, which is improper since there is no preexisting `?`, and results in a URL that doesn't work and breaks appellate PACER. Doh!

Fix this and a few other instances of URL handling in `utils.js`, thusly. This code is untested:

<hr>



Don't feed the URLSearchParams() constructor an entire URL, it takes only a query string. Feeding it a full URL causes it to misparse the first query string, if any, merging it with the URL. In practice this was not an actual problem, but could have been.

Similarly, don't set a URL search parameter by concatenating "&caseid=xyz"; this fails when there is no preexisting search string:(i.e. no ?foobar), and causes the RECAP extension to break URLs. Instead, use the URL+URLSearchParamers abstractions.

This has the side effect of converting relative URLs to absolute.  I don't think this is an actual problem?

Lastly, don't parse a query string by hand with split('?') -- use the URL constructor to do it.