### PR TITLE
Be clear when we modify links in a webpage, by adding two markers.

### DIFF
--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -272,14 +272,14 @@ let APPELLATE = {
       // store extra information on anchors to use it while handling the onClick listener
       let docId = PACER.getDocumentIdFromUrl(clonedNode.href);
 
-      clonedNode.setAttribute('data-pacer_doc_id', docId);
+      clonedNode.dataset.pacerDocId = docId;
       if (doDoc && doDoc.doc_id) {
-        clonedNode.setAttribute('data-pacer_dls_id', doDoc.doc_id);
+        clonedNode.dataset.pacerDlsId = doDoc.doc_id;
       }
-      clonedNode.setAttribute('data-pacer_case_id', pacerCaseId);
-      clonedNode.setAttribute('data-pacer_tab_id', tabId);
-      clonedNode.setAttribute('data-document_number', docNum ? docNum : docId);
-      clonedNode.setAttribute('data-attachment_number', attNumber);
+      clonedNode.dataset.pacerCaseId = pacerCaseId;
+      clonedNode.dataset.pacerTabId = tabId;
+      clonedNode.dataset.documentNumber = docNum ? docNum : docId;
+      clonedNode.dataset.attachmentNumber = attNumber;
 
       links.push(docId);
     });

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -158,6 +158,8 @@ let APPELLATE = {
       // attribute allow us to get the desired HTML element.
       let caseSummaryAnchor = caseQueryAnchor.parentElement.firstChild;
       caseSummaryAnchor.setAttribute('href', `${caseSummaryAnchor.href}&caseId=${caseId}`);
+      caseSummaryAnchor.dataset.recap = 'Modified by RECAP Extension to add caseId attribute.';
+      caseSummaryAnchor.classList.add('recap_modified');
     });
   },
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -319,7 +319,7 @@ const recapAddLatestFilingButton = (result) => {
   const anchor = document.createElement('a');
   anchor.classList.add('recap-filing-button');
   anchor.title = 'Autofill the form to get the latest content not yet in RECAP, omitting parties and member cases.';
-  anchor.setAttribute('data-date_from', formatted_date);
+  anchor.dataset.dateFrom = formatted_date;
   anchor.href = '#';
 
   const img = document.createElement('img');
@@ -357,7 +357,7 @@ const recapBanner = (result) => {
   anchor.href = `https://www.courtlistener.com${result.absolute_url}`
   
   const time = document.createElement('time');
-  time.setAttribute('data-livestamp', result.date_modified);
+  time.dataset.livestamp = result.date_modified;
   time.setAttribute('title', result.date_modified);
   time.innerHTML = result.date_modified;
 


### PR DESCRIPTION
Be clear when we modify links in a webpage, by adding two markers.

Specifically, change two attributes:
* Add a `data-recap` attribute explaining that it was modified, and
* Append `recap_modified` to the CSS class list.

Resulted from a Slack discussion this morning in light of #324 where it was not obvious upon inspection that the RECAP extension was messing with the page and breaking the URL, and it would have aided debugging to have done so.

I don't quite understand the test infrastructure and where to add a test to check this stuff -- it seems like there's zero test coverage for `addCaseIdToDocketSummaryLink()` and I don't know quite where to begin, so no tests.

As a prereq, consistently use the `.dataset` API rather than rolling our own.