### PR TITLE
feat(pacer): Filter out show_doc links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
 
 Fixes:
  - Support for Safari on macOS and iPhone([#332](https://github.com/freelawproject/recap/issues/332)).
+ - Better document link filtering on district and appellate court reports([#341](https://github.com/freelawproject/recap/issues/341)).
 
 For developers:
  - Nothing yet

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -1303,6 +1303,39 @@ describe('The ContentDelegate class', function () {
         '034031424911': '123456',
       });
     });
+    it('should work only for doc1 links', async function () {
+      let test_links = [];
+      let urls = [
+        'https://ecf.canb.uscourts.gov/notacase/034031424909',
+        'https://ecf.canb.uscourts.gov/doc1/034031424910',
+        'https://ecf.canb.uscourts.gov/doc1/034031424911',
+        'https://ecf.pamb.uscourts.gov/cgi-bin/show_doc.pl?caseid=260973&claim_id=15342915&claim_num=1-1&magic_num=MAGIC',
+        'https://ecf.pamb.uscourts.gov/cgi-bin/show_doc.pl?caseid=171908&de_seq_num=981&dm_id=15184563&doc_num=287'
+      ];
+      for (url of urls) {
+        link = document.createElement('a');
+        link.href = url;
+        test_links.push(link);
+      }
+      const docketQueryWithLinks = new ContentDelegate(
+        tabId,
+        docketQueryUrl, // url
+        docketQueryPath, // path
+        'canb', // court
+        '123456', // pacer_case_id
+        'redfox', // pacer_doc_id
+        test_links // links
+      );
+      spyOn(PACER, 'hasPacerCookie').and.returnValue(true);
+      spyOn(PACER, 'getDocumentIdFromUrl').and.callThrough();
+      chrome.storage.local.set = function (storagePayload, cb) {
+        const docs = storagePayload[tabId].docsToCases;
+        documents = docs;
+        cb();
+      };
+      await docketQueryWithLinks.findAndStorePacerDocIds();
+      expect(PACER.getDocumentIdFromUrl).toHaveBeenCalledTimes(2);
+    })
   });
 
   // TODO: Figure out where the functionality of

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -85,6 +85,31 @@ describe('The PACER module', function () {
     });
   });
 
+  describe('isDoc1Url', function () {
+    it('matches a valid doc1 URL', function () {
+      expect(PACER.isDoc1Url(singleDocUrl)).toBe(true);
+    });
+
+    it('matches a valid appellate document URL', function () {
+      expect(PACER.isDoc1Url(appellateDocumentUrl)).toBe(true);
+    });
+
+    const showDocUrl =
+      'https://ecf.cacd.uscourts.gov/cgi-bin/show_doc.pl?' + 'caseid=560453&de_seq_num=24&dm_id=15521444&doc_num=7';
+
+    it('returns false for a valid show_doc document URL', function () {
+      expect(PACER.isDoc1Url(showDocUrl)).toBe(false);
+    });
+
+    it('returns false for a non-document court URL', function () {
+      expect(PACER.isDoc1Url(docketQueryUrl)).toBe(false);
+    });
+
+    it('returns false for patent nonsense', function () {
+      expect(PACER.isDoc1Url(nonsenseUrl)).toBe(false);
+    });
+  });
+
   describe('isDocketQueryUrl', function () {
     it('matches a docket query URL with digits in the query string', function () {
       expect(PACER.isDocketQueryUrl(docketQueryUrl)).toBe(true);

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -232,7 +232,7 @@ let APPELLATE = {
     let links = [];
     let docsToCases = {};
     Array.from(nodeList).map((a) => {
-      if (!PACER.isDocumentUrl(a.href)) return;
+      if (!PACER.isDoc1Url(a.href)) return;
 
       let docNum = PACER.getDocNumberFromAnchor(a) || queryParameters.get('recapDocNum');
       let doDoc = PACER.parseDoDocPostURL(a.getAttribute('onclick'));

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -121,7 +121,7 @@ ContentDelegate.prototype.checkRestrictions = function () {
 // Use a variety of approaches to get and store pacer_doc_id to pacer_case_id
 // mappings in local storage.
 ContentDelegate.prototype.findAndStorePacerDocIds = async function () {
-  
+
   // Not all pages have a case ID, and there are corner-cases in merged dockets
   // where there are links to documents on another case.
   let page_pacer_case_id = this.pacer_case_id
@@ -135,10 +135,9 @@ ContentDelegate.prototype.findAndStorePacerDocIds = async function () {
     debug(3, `Z doc ${this.pacer_doc_id} to ${page_pacer_case_id}`);
     docsToCases[this.pacer_doc_id] = page_pacer_case_id;
   }
-
   for (let i = 0; i < this.links.length; i++) {
     let link = this.links[i];
-    if (PACER.isDocumentUrl(link.href)) {
+    if (PACER.isDoc1Url(link.href)) {
       let pacer_doc_id = PACER.getDocumentIdFromUrl(link.href);
       $(link).data('pacer_doc_id', pacer_doc_id);
       this.pacer_doc_ids.push(pacer_doc_id);
@@ -201,7 +200,7 @@ ContentDelegate.prototype.handleDocketQueryUrl = function () {
   if (!PACER.isDocketQueryUrl(this.url)) {
     return;
   }
-  
+
   this.recap.getAvailabilityForDocket(this.court, this.pacer_case_id, null, (result) => {
     if (result.count === 0) {
       console.warn('RECAP: Zero results found for docket lookup.');
@@ -213,7 +212,7 @@ ContentDelegate.prototype.handleDocketQueryUrl = function () {
         const dateToInput = document.querySelector('input[name=date_to]');
         const form = document.querySelector('form');
         const div = document.createElement('div');
-        
+
         div.classList.add('recap-banner');
         div.appendChild(recapAlertButton(this.court, this.pacer_case_id, true));
         form.appendChild(recapBanner(result.results[0]));

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -64,11 +64,18 @@ let PACER = {
   },
 
   // Returns true if the given URL looks like a link to a PACER document.
-  // For CMECF District:
-  //   https://ecf.dcd.uscourts.gov/doc1/04503837920
-  // For CMECF Appellate:
-  //   https://ecf.ca2.uscourts.gov/docs1/00205695758
   isDocumentUrl: function (url) {
+    // This function will return true for the following URLs:
+    //
+    //  - Claims:
+    //    - /cgi-bin/show_doc.pl?caseid=171908&claim_id=15151763&claim_num=7-1&magic_num=MAGIC
+    //    - /doc1/072035305573?caseid=671949&claim_id=34489904&claim_num=28-1&magic_num=MAGIC&pdf_header=1
+    //
+    //  - Docket entry:
+    //	  - /cgi-bin/show_doc.pl?caseid=171908&de_seq_num=981&dm_id=15184563&doc_num=287
+    //    - /doc1/150014580417
+    //    - /docs1/00205695758
+    //
     if (
         url.match(/\/(?:doc1|docs1)\/\d+/) ||
         url.match(/\/cgi-bin\/show_doc/) ||
@@ -77,6 +84,21 @@ let PACER = {
       if (PACER.getCourtFromUrl(url)) {
         return true;
       }
+    }
+    return false;
+  },
+
+  // Returns true if the given URL is a doc1 link.
+  isDoc1Url: function (url) {
+    // This function will return true for the following URLs:
+    //
+    // For CMECF District:
+    //   https://ecf.dcd.uscourts.gov/doc1/04503837920
+    // For CMECF Appellate:
+    //   https://ecf.ca2.uscourts.gov/docs1/00205695758
+    //
+    if (url.match(/\/(?:doc1|docs1)\/\d+/) && PACER.getCourtFromUrl(url)) {
+      return true;
     }
     return false;
   },


### PR DESCRIPTION
This commit fixes cases iii and iv from https://github.com/freelawproject/recap/issues/341.

This PR introduces the following changes:

- Adds a new utility function that only matches `doc1` URLs. This new helper function allows us to filter out all the `show_doc.pl` links on the reports before the extension tries to extract the `pacer_doc_id`.

- Add tests for the method called` isDoc1Url`.

- Updates the docstring for the `isDocumentUrl` method.
