### PR TITLE
fix(appellate): Tweak the utility function that upload free documents

### DIFF
--- a/spec/AppellateSpec.js
+++ b/spec/AppellateSpec.js
@@ -8,8 +8,8 @@ describe('The Appellate module', function () {
     'http://www.ca9.uscourts.gov/opinions/',
   ];
   const documentLinks = [
-    'https://ecf.ca9.uscourts.gov/docs1/009031927529',
-    'https://ecf.ca9.uscourts.gov/docs1/009031956734',
+    {href: 'https://ecf.ca9.uscourts.gov/docs1/009031927529', onClick:"return doDocPostURL('009031927529','290338');"},
+    {href: 'https://ecf.ca9.uscourts.gov/docs1/009031956734', onClick:"return doDocPostURL('009031956734','290338');"}
   ];
   const searchParamsWithCaseId = new URLSearchParams('servlet=DocketReportFilter.jsp&caseId=318547');
   const searchParamsWithoutCaseId = new URLSearchParams('servlet=DocketReportFilter.jsp');
@@ -178,7 +178,8 @@ describe('The Appellate module', function () {
           docLinksDiv.setAttribute('id', 'links');
           documentLinks.forEach(function (item, index) {
             let anchor = document.createElement('a');
-            anchor.href = item;
+            anchor.href = item['href'];
+            anchor.setAttribute('onclick', item['onClick'])
             anchor.title = 'Open Document';
             docLinksDiv.appendChild(anchor);
           });
@@ -190,10 +191,19 @@ describe('The Appellate module', function () {
         });
 
         it('returns array with doc_ids', function () {
-          let anchors = document.querySelectorAll('#links > a');
-          let { links, _ } = APPELLATE.findDocLinksFromAnchors(anchors, '3', new URLSearchParams('docNum=30'));
+          let anchors = document.getElementsByTagName('a');
+          console.log(anchors)
+          let { links, _ } = APPELLATE.findDocLinksFromAnchors(anchors, '3', new URLSearchParams({ recapDocNum: "30"}), '20-15019');
           expect(links.length).toBe(2);
           expect(links).toEqual(['009031927529', '009031956734']);
+
+          for (let i = 0; i < anchors.length; i++) {
+            let item = anchors[i]
+            expect(item.dataset.pacerDlsId).toBe(links[i]);
+            expect(item.dataset.pacerCaseId).toBe('290338');
+            expect(item.dataset.pacerTabId).toBe('3');
+            expect(item.dataset.attachmentNumber).toBe('0');
+          }
         });
       });
     });

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -80,7 +80,7 @@ AppellateDelegate.prototype.handleCaseSelectionPage = async function () {
     let anchors = dataTable.querySelectorAll('a');
 
     this.docketNumber = anchors[0].innerHTML
-   
+
     await updateTabStorage({
       [this.tabId]: {
         caseId: this.pacer_case_id,
@@ -234,7 +234,7 @@ AppellateDelegate.prototype.attachRecapLinksToEligibleDocs = async function () {
         `RECAP: Got results from API. Running callback on API results to ` + `attach links and icons where appropriate.`
       );
       for (let i = 0; i < this.links.length; i++) {
-        let pacer_doc_id = $(this.links[i]).data('pacer_doc_id');
+        let pacer_doc_id = this.links[i].dataset.pacerDocId;
         if (!pacer_doc_id) {
           continue;
         }
@@ -363,11 +363,11 @@ AppellateDelegate.prototype.handleSingleDocumentPageView = async function () {
   overwriteFormSubmitMethod();
 
   this.pacer_case_id = await APPELLATE.getCaseId(this.tabId, this.queryParameters, this.docId);
-  
+
   let title = document.querySelectorAll('strong')[1].innerHTML;
   let dataFromTitle = APPELLATE.parseReceiptPageTitle(title);
   this.docketNumber =  dataFromTitle.docket_number
-  
+
   await updateTabStorage({
     [this.tabId]: {
       caseId: this.pacer_case_id,

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -210,8 +210,8 @@ let APPELLATE = {
   onClickEventHandlerForDocLinks: function (e) {
     let target = e.currentTarget || e.srcElement;
     let params = {
-      dls_id: target.dataset.pacer_dls_id,
-      caseId: target.dataset.pacer_case_id,
+      dls_id: target.dataset.pacerDlsId,
+      caseId: target.dataset.pacerCaseId,
       servlet: 'ShowDoc',
       dktType: 'dktPublic',
     };

--- a/src/pdf_upload.js
+++ b/src/pdf_upload.js
@@ -135,14 +135,14 @@ const handleFreeDocResponse = async function (type, ab, xhr) {
   if (type === 'application/pdf') {
     let blob = new Blob([new Uint8Array(ab)], { type: type });
     let dataUrl = await blobToDataURL(blob);
-    await updateTabStorage({ [this.dataset.pacer_tab_id]: { ['pdf_blob']: dataUrl } });
-    // get data attributes through the dataset object  
+    await updateTabStorage({ [this.dataset.pacerTabId]: { ['pdf_blob']: dataUrl } });
+    // get data attributes through the dataset object
     let options = {
       court: PACER.getCourtFromUrl(window.location.href),
-      pacer_doc_id: this.dataset.pacer_doc_id,
-      pacer_case_id: this.dataset.pacer_case_id,
-      document_number: this.dataset.document_number,
-      attachment_number: this.dataset.attachment_number,
+      pacer_doc_id: this.dataset.pacerDocId,
+      pacer_case_id: this.dataset.pacerCaseId,
+      document_number: this.dataset.documentNumber,
+      attachment_number: this.dataset.attachmentNumber,
     };
     await chrome.runtime.sendMessage({ message: 'upload', type: 'doc', options });
   }


### PR DESCRIPTION
While I was going through the manual [QA-Testing](https://github.com/freelawproject/recap/wiki/QA-Testing) list, I noticed the extension was not uploading free docs from appellate courts. I debugged the code and realized the `handleFreeDocResponse` method was failing because it wasn't getting the data attributes from the anchors. I remembered We tweaked the style of some of those attributes in #325, so this PR tweaks the naming style of the remaining data attributes and fixes the bug with the handleFreeDocResponse method.