### PR TITLE
feat(content.js): Tweak logic to get the pacer_case_id from input

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,8 @@ Changes:
 Fixes:
  - Support for Safari on macOS and iPhone([#332](https://github.com/freelawproject/recap/issues/332)).
  - Better document link filtering on district and appellate court reports([#341](https://github.com/freelawproject/recap/issues/341)).
+ - Change the naming style of the data attributes the extension attaches to documents links.
+ - Better case ID capturing on district court docket reports.
 
 For developers:
  - Nothing yet

--- a/src/content.js
+++ b/src/content.js
@@ -90,7 +90,7 @@ async function addRecapInformation(msg) {
 // the id "all_case_id" are observed
 function handleCaseIdChange(mutationRecords) {
   let target = mutationRecords[0].target;
-  if (target.value != 0) {
+  if (target.value != 0 && target.value != '0') {
     pacer_case_id = target.value;
     url = PACER.formatDocketQueryUrl(url, pacer_case_id);
     getTabIdForContentScript().then((msg) => {
@@ -136,7 +136,7 @@ if (caseNumberInput) {
 // check the page for the value in the input with the id 'all_case_ids'.
 if (!pacer_case_id) {
   let inputValue = !!allCaseInput && allCaseInput.value;
-  if (!!inputValue) {
+  if (!!inputValue && inputValue!='0') {
     pacer_case_id = inputValue;
     url = PACER.formatDocketQueryUrl(url, pacer_case_id);
   }


### PR DESCRIPTION
This commit tweaks the logic to check the value of the hidden input with the id 'all_case_ids' before updating the `pacer_case_id`.

We checked this input in https://github.com/freelawproject/recap-chrome/pull/273 and found that it was empty when there wasn't a cookie for the case number ( here's a comment about it: https://github.com/freelawproject/recap-chrome/pull/273#pullrequestreview-1184750272) but I noticed that the input could also use `value='0'`, so the extension updates the `pacer_case_id`, tries to lookup a case using the API and it also creates a banner in the **Docket Query Page** linked to this [case](https://www.courtlistener.com/docket/66992224/united-states-v-sandoval/) but the user hasn't search any case.

Here's a screenshot of this bug:

![image](https://github.com/freelawproject/recap-chrome/assets/55959657/d9d6b294-5377-4058-b48d-e8f7f154f461)
