### PR TITLE
fix(utils): Fix broken autofill button

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
  - None yet
 
 Fixes:
- - None yet
+ - Fix button to autofill docket query form([#344](https://github.com/freelawproject/recap/issues/344)).
 
 For developers:
  - Nothing yet

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -292,6 +292,7 @@ describe('The ContentDelegate class', function () {
       );
       const autofill = document.querySelector('.recap-filing-button');
       expect(autofill).not.toBeNull();
+      expect(autofill.dataset.dateFrom).toBe('04/20/2015')
     });
 
     it("don't inserts the autofill button when a docket don't have last_filing", function () {

--- a/src/utils.js
+++ b/src/utils.js
@@ -335,7 +335,7 @@ const recapAddLatestFilingButton = (result) => {
     let filedCheckbox = document.querySelector('input[value="Filed"]');
     let terminatedParties = document.getElementById('terminated_parties');
 
-    dateInput.value = target.dataset.date_from;
+    dateInput.value = target.dataset.dateFrom;
     partyCheckbox.checked = false;
     terminatedParties.checked = false;
     filedCheckbox.checked = true;


### PR DESCRIPTION
This PR updates the naming style of the attribute that stores the date in the autofill button and tweaks the tests to check we're using the right attribute name.

This PR fixes https://github.com/freelawproject/recap/issues/344


![fix-extension-autofill](https://github.com/freelawproject/recap-chrome/assets/55959657/d0a48da7-6f21-4783-9b63-2d3d992f184d)
