### PR TITLE
Improve Document Selection Menu page matching

### DIFF
--- a/src/pacer.js
+++ b/src/pacer.js
@@ -317,9 +317,11 @@ let PACER = {
     let mainContent = document.getElementById("cmecfMainContent");
     // End this function early if we're on a management PACER page
     if (!mainContent){ return false }
-    let bottomNote = mainContent.lastChild.textContent.includes('view each document individually')
+    let paragraphs = mainContent.getElementsByTagName("p");
+    let topNote = paragraphs.length ? paragraphs[0].textContent.includes('Document Selection Menu') : false
+    let bottomNote = mainContent.lastChild.textContent.includes('view each document individually');
     let pageCheck = PACER.isDocumentUrl(url) && ( 
-      !!buttonText || !!bigFile || !!bottomNote);
+      !!buttonText || !!bigFile || !!topNote || !!bottomNote);
     return !!pageCheck;
   },
 


### PR DESCRIPTION
The existing match conditions for attachment pages doesn't seem to be reliable(ie for example on `cacd`), lets just add a match condition for the "Document Selection Menu" text at the top as well which seems to fix these issues.