### PR TITLE
fix(appellate): Normalize document number and dls_ids

### DIFF
--- a/spec/AppellateSpec.js
+++ b/spec/AppellateSpec.js
@@ -13,8 +13,8 @@ describe('The Appellate module', function () {
       onClick: "return doDocPostURL('009031927529','290338');",
     },
     {
-      href: 'https://ecf.ca9.uscourts.gov/docs1/009031956734',
-      onClick: "return doDocPostURL('009031956734','290338');",
+      href: 'https://ecf.ca9.uscourts.gov/docs1/009131956734',
+      onClick: "return doDocPostURL('009131956734','290338');",
     },
   ];
   const searchParamsWithCaseId = new URLSearchParams('servlet=DocketReportFilter.jsp&caseId=318547');

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -441,6 +441,12 @@ AppellateDelegate.prototype.onDocumentViewSubmit = function (event) {
     dataFromTitle.att_number = this.queryParameters.get('recapAttNum');
   }
 
+  if (dataFromTitle.doc_number.length > 9) {
+    // If the number is really big, it's probably a court that uses
+    // pacer_doc_id instead of regular docket entry numbering.
+    dataFromTitle.doc_number = PACER.cleanPacerDocId(dataFromTitle.doc_number);
+  }
+
   if (!dataFromTitle) {
     form.submit();
     return;

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -280,7 +280,7 @@ let APPELLATE = {
 
       clonedNode.dataset.pacerDocId = docId;
       if (doDoc && doDoc.doc_id) {
-        clonedNode.dataset.pacerDlsId = doDoc.doc_id;
+        clonedNode.dataset.pacerDlsId = PACER.cleanPacerDocId(doDoc.doc_id);
       }
       clonedNode.dataset.pacerCaseId = pacerCaseId;
       clonedNode.dataset.pacerTabId = tabId;


### PR DESCRIPTION
This PR adds logic to normalize the document number when the appellate court uses the pacer_doc_id instead of the regular docket entry numbering.