### PR TITLE
fix(appellate): Remove the logic to normalize the pacer_dls_id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Changes:
 Fixes:
  - More robust logic to get the document id from appellate courts([#340](https://github.com/freelawproject/recap/issues/340))
  - Normalize document numbers from appellate courts that uses the pacer_doc_id instead of the regular docket entry numbering([#2877](https://github.com/freelawproject/courtlistener/issues/2877)).
+ - Remove logic to normalize the pacer_dls_id attribute in the document links([#338](https://github.com/freelawproject/recap-chrome/pull/338))
 
 For developers:
  - Nothing yet

--- a/spec/AppellateSpec.js
+++ b/spec/AppellateSpec.js
@@ -11,10 +11,12 @@ describe('The Appellate module', function () {
     {
       href: 'https://ecf.ca9.uscourts.gov/docs1/009031927529',
       onClick: "return doDocPostURL('009031927529','290338');",
+      dlsId: '009031927529',
     },
     {
       href: 'https://ecf.ca9.uscourts.gov/docs1/009131956734',
       onClick: "return doDocPostURL('009131956734','290338');",
+      dlsId: '009131956734',
     },
   ];
   const searchParamsWithCaseId = new URLSearchParams('servlet=DocketReportFilter.jsp&caseId=318547');
@@ -50,10 +52,9 @@ describe('The Appellate module', function () {
   describe('getDocIdFromURL', function () {
     it('returns the document id ', function () {
       for (const item of showDocURLs) {
-        var queryString = new URLSearchParams(item.url)
+        var queryString = new URLSearchParams(item.url);
         expect(APPELLATE.getDocIdFromURL(queryString)).toBe(item.docId);
       }
-
     });
   });
 
@@ -233,7 +234,7 @@ describe('The Appellate module', function () {
 
           for (let i = 0; i < anchors.length; i++) {
             let item = anchors[i];
-            expect(item.dataset.pacerDlsId).toBe(links[i]);
+            expect(item.dataset.pacerDlsId).toBe(documentLinks[i]['dlsId']);
             expect(item.dataset.pacerCaseId).toBe('290338');
             expect(item.dataset.pacerTabId).toBe('3');
             expect(item.dataset.attachmentNumber).toBe('0');

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -280,7 +280,8 @@ let APPELLATE = {
 
       clonedNode.dataset.pacerDocId = docId;
       if (doDoc && doDoc.doc_id) {
-        clonedNode.dataset.pacerDlsId = PACER.cleanPacerDocId(doDoc.doc_id);
+        // don't normalize this attribute because we use it to check whether a doc is free or not
+        clonedNode.dataset.pacerDlsId = doDoc.doc_id;
       }
       clonedNode.dataset.pacerCaseId = pacerCaseId;
       clonedNode.dataset.pacerTabId = tabId;


### PR DESCRIPTION
While going through the QA steps, I realized the extension failed to upload free documents. After debugging the code, I noticed we're using the pacer_dls_id attribute in the [onClickEventHandlerForDocLinks](https://github.com/freelawproject/recap-chrome/blob/main/src/appellate/utils.js#L210) to create the request that allows us to check whether the doc link returns an HTML page (the view document page) or a pdf file (when it's free). sending the normalized version of the dls_id always returns an HTML page even when the doc is an opinion (which is a free doc).

This PR removes the logic to normalize the `dls_id.` 