### PR TITLE
fix(background): Tweak logic to inject script programmatically

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,8 +11,8 @@ Changes:
  - None yet
 
 Fixes:
- - None yet
- - 
+ - More robust logic to inject content scripts([#346](https://github.com/freelawproject/recap/issues/346))
+
 For developers:
  - Nothing yet
 


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/recap/issues/346.

The current implementation of the extension inserts scripts listed in the `CONTENT_SCRIPT_FILES` array calling the `executeScripts` method sequentially inside a for-loop. I think this approach is causing the bug in Firefox because the  `executeScript` is an asynchronous function, so there may be calls that are still running when the next one starts (which is not desired). 

We need to make sure the extension injects a new script after the previous one succeeds and so on. Luckily we can pass a callback function`executeScripts` method so we can nest the `executeScript` calls like this:

```
chrome.tabs.executeScript(null, { file: "jquery.js" }, function() {
      chrome.tabs.executeScript(null, { file: "master.js" }, function() {
          chrome.tabs.executeScript(null, { file: "helper.js" }, function() {
              chrome.tabs.executeScript(null, { file: "client.js" })
          })
      })
  })
```

The previous code makes sure the `master.js` script is injected after the `jquery.js` file and so on, but the nesting can get unwieldy so this PR adds a helper function to abstract the previous approach and handle the programmatically script injection. 