### PR TITLE
feat(pacer): Adds warning about combined pdfs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 The following changes are not yet released, but are code complete:
 
 Features:
- - None yet
+ - Adds a warning to let users know that combined PDFs won't be uploaded to the RECAP Archive([#337](https://github.com/freelawproject/recap/issues/337), [#341](https://github.com/freelawproject/recap-chrome/pull/341))
 
 Changes:
  - None yet

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -32,6 +32,9 @@ AppellateDelegate.prototype.dispatchPageHandler = function () {
     case 'CaseQuery.jsp':
       this.handleCaseQueryPage();
       break;
+    case 'ShowDocMulti':
+      this.handleCombinedPdfPageView();
+      break
     default:
       if (APPELLATE.isAttachmentPage()) {
         this.handleAttachmentPage();
@@ -384,6 +387,11 @@ AppellateDelegate.prototype.handleAttachmentPage = async function () {
     'APPELLATE_ATTACHMENT_PAGE',
     (ok) => callback(ok)
   );
+};
+
+AppellateDelegate.prototype.handleCombinedPdfPageView = async function () {
+  let warning = combinedPdfWarning()
+  document.body.appendChild(warning)
 };
 
 // If this page offers a single document, intercept navigation to the document view page.

--- a/src/content.js
+++ b/src/content.js
@@ -77,6 +77,10 @@ async function addRecapInformation(msg) {
     // creates a <form> element and calls submit() on it, so we hook into submit().
     content_delegate.handleSingleDocumentPageView();
 
+    // If this page offers a combined document, inserts a warning to let the user
+    // know this document is not supported.
+    content_delegate.handleCombinedPDFView();
+
     // If this is a Clams Register, we upload it to RECAP
     content_delegate.handleClaimsPageView();
 

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -682,6 +682,18 @@ ContentDelegate.prototype.handleZipFilePageView = function () {
   window.addEventListener('message', this.onDownloadAllSubmit.bind(this));
 };
 
+// If the page offers a combined document, inserts a warning to let
+// the user know this document won't be uploaded.
+ContentDelegate.prototype.handleCombinedPDFView = function () {
+  if (!PACER.isCombinedPdfPage(this.url, document)) {
+    return false;
+  }
+  // query the main div of the page
+  let mainDiv = document.getElementById(id='cmecfMainContent')
+  pdfWarning = combinedPdfWarning()
+  mainDiv.append(pdfWarning)
+};
+
 ContentDelegate.prototype.handleClaimsPageView = function () {
   // return if not a claims register page
   if (!PACER.isClaimsRegisterPage(this.url, document)) {

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -335,7 +335,27 @@ let PACER = {
       inputs[inputs.length-1].value === "Download Documents"
     return !!pageCheck
   },
+  
+  // Returns true if this is a combined PDF page (confirmation of
+  // pricing for all documents to receive a combined PDF file with
+  // all of them)
+  isCombinedPdfPage: function (url, document) {
+    // This method checks the page has the following elements:
+    //  - The URL contains the "zipit" parameters and its value is 0
+    //  - The URL contains the word "show_multidocs.pl"
+    //  - shows 2 or more buttons
+    let queryParameters = new URLSearchParams(window.location.search);
+    let isZipFile = queryParameters.get('zipit');
+    let buttons = document.getElementsByTagName('input');
+    let pageCheck =
+      !!url.match(/\/show_multidocs\.pl\?/) &&
+      isZipFile == 0 &&
+      buttons.length > 1 &&
+      buttons[buttons.length - 1].value === 'View Document';
 
+    return !!pageCheck;
+  },
+  
   // Claims Register Page includes an h2 tag with the court and words "Claims Register"
   // exampleUrl: https://ecf.nyeb.uscourts.gov/cgi-bin/SearchClaims.pl?610550152546515-L_1_0-1
   // exampleHeader: <h2>Eastern District of New York<br>Claims Register </h2>

--- a/src/utils.js
+++ b/src/utils.js
@@ -408,6 +408,43 @@ const insertAvailableDocBanner = (doc_url, html_element) =>{
     .appendTo($(html_element));
 }
 
+// Creates a div element to let user know they're trying to buy a combined PDF
+const combinedPdfWarning = () => {
+  let img = document.createElement('img');
+  img.src = chrome.extension.getURL('assets/images/disabled-38.png');
+  img.style.width = 'auto';
+  img.style.height = 'auto';
+  img.style.maxWidth = '38px';
+  img.style.maxHeight = '38px';
+
+  let imgDiv = document.createElement('div');
+  imgDiv.style.padding = '12px';
+  imgDiv.style.display = 'flex';
+  imgDiv.style.alignItems = 'center';
+  imgDiv.appendChild(img);
+
+  let text = document.createElement('p');
+  text.innerHTML = `This document <b>will not be uploaded</b> to the RECAP Archive because the extension has detected that this page may return a combined PDF and consistently splitting these files in a proper manner is not possible for now.`;
+
+  let messageDiv = document.createElement('div');
+  messageDiv.style.display = 'flex';
+  messageDiv.style.alignContent = 'center';
+  messageDiv.appendChild(text);
+
+  let innerDiv = document.createElement('div');
+  innerDiv.classList.add('recap-banner');
+  innerDiv.style.display = 'flex';
+  innerDiv.appendChild(imgDiv);
+  innerDiv.appendChild(messageDiv);
+
+  let outerDiv = document.createElement('div');
+  outerDiv.style.display = 'flex';
+  outerDiv.style.justifyContent = 'center';
+  outerDiv.appendChild(innerDiv);
+
+  return outerDiv;
+};
+
 //Given a pacer_doc_id, return the pacer_case_id that it is associated with
 async function getPacerCaseIdFromPacerDocId(tabId, pacer_doc_id) {
   const tabStorage = await getItemsFromStorage(tabId);


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/recap/issues/337.

Here are screenshots of the new warning:

- **District courts:**
![image](https://github.com/freelawproject/recap-chrome/assets/55959657/5dfea05e-33d8-4ab8-8eed-41680a7f2a73)


- **Appellate courts:**
![image](https://github.com/freelawproject/recap-chrome/assets/55959657/00a129b8-4737-440c-9f6f-c42710f1014c)
