### PR TITLE
feat(toolbar): Show warning sign in ACMS websites

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 The following changes are not yet released, but are code complete:
 
 Features:
- - None yet
+ - Adds a warning sign to the toolbar icon when users are on a ACMS website([#346](https://github.com/freelawproject/recap-chrome/pull/346))
 
 Changes:
  - Adds permissions to access ACMS URLs. ACMS is the new CM/ECF replacement

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -66,6 +66,10 @@ let PACER = {
     return null;
   },
 
+  isACMSWebsite: function(url){
+    return url.toLowerCase().includes('azurewebsites.us');
+  },
+
   // Returns true if the URL is for the login page
   isLoginPage: function(url) {
     return this.getCourtFromUrl(url) === 'login';

--- a/src/toolbar_button.js
+++ b/src/toolbar_button.js
@@ -59,6 +59,12 @@ function updateToolbarButton(tab) {
           '19': 'assets/images/grey-19.png',
           '38': 'assets/images/grey-38.png'
         });
+      } else if (PACER.isACMSWebsite(tab.url)) {
+        // ACMS website. Show warning.
+        setTitleIcon('ACMS is not supported', {
+          '19': 'assets/images/warning-19.png',
+          '38': 'assets/images/warning-38.png'
+        });
       } else {
         // It's a valid PACER URL. Therefore either show the nice blue icon or
         // show the blue icon with a warning, if receipts are disabled.


### PR DESCRIPTION
This PR adds a helper method to identify ACMS URLs and logic to show a warning sign in the toolbar icon when users are on those new websites.

Here's a screenshot of the toolbar icon:

![image](https://github.com/freelawproject/recap-chrome/assets/55959657/6b7b61ee-4d62-4b94-a27e-88f560f0abc5)
