### PR TITLE
fix(content_delegate): Fix zip upload in district courts

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Features:
  - None yet
 
 Changes:
- - None yet
+ - Enhanced logic to retrieve Zip URLs([#352](https://github.com/freelawproject/recap/issues/352)).
 
 Fixes:
  - None yet

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -595,9 +595,7 @@ ContentDelegate.prototype.onDownloadAllSubmit = async function (event) {
   const browserSpecificFetch =
     navigator.userAgent.indexOf('Safari') + navigator.userAgent.indexOf('Chrome') < 0 ? content.fetch : window.fetch;
 
-  // load options
   const options = await getItemsFromStorage('options');
-  // generate the filename
   const pacerCaseId = event.data.id.match(/caseid=(\d*)/)[1];
   const filename = generateFileName(options, pacerCaseId);
 

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -598,7 +598,7 @@ ContentDelegate.prototype.onDownloadAllSubmit = async function (event) {
   // load options
   const options = await getItemsFromStorage('options');
   // generate the filename
-  const pacerCaseId = event.data.id.match(/caseid\=\d*/)[0].replace(/caseid\=/, '');
+  const pacerCaseId = event.data.id.match(/caseid=(\d*)/)[1];
   const filename = generateFileName(options, pacerCaseId);
 
   // show loading message

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -545,7 +545,16 @@ ContentDelegate.prototype.onDownloadAllSubmit = async function (event) {
     const page = document.createElement('html');
     page.innerHTML = html;
     const frames = page.querySelectorAll('iframe');
-    return frames[0].src;
+    if (frames.length) {
+      return frames[0].src;
+    }
+    // Try to extract the PDF URL from the HTML
+    const showTempURL = html.match(/\/cgi-bin\/show_temp.pl?(.*)/);
+    if (!showTempURL) {
+      return null;
+    }
+    // Clean the match found in the HTML
+    return showTempURL[0].replace(';"', '');
   };
 
   // helper function - convert string to html document
@@ -588,7 +597,6 @@ ContentDelegate.prototype.onDownloadAllSubmit = async function (event) {
 
   // fetch the html page which contains the <iframe> link to the zip document.
   const htmlPage = await browserSpecificFetch(event.data.id).then((res) => res.text());
-  console.log('RECAP: Successfully submitted zip file request');
   const zipUrl = extractUrl(htmlPage);
   //download zip file and save it to chrome storage
   const blob = await fetch(zipUrl).then((res) => res.blob());
@@ -622,10 +630,17 @@ ContentDelegate.prototype.onDownloadAllSubmit = async function (event) {
           const link = `<a id="recap-download" href=${blobUrl} download=${filename} width="0" height="0"/>`;
           const htmlBody = stringToDocBody(htmlPage);
           const frame = htmlBody.querySelector('iframe');
-          frame.insertAdjacentHTML('beforebegin', link);
-          frame.src = '';
-          frame.onload = () => document.getElementById('recap-download').click();
-          document.body = htmlBody;
+          if (frame) {
+            frame.insertAdjacentHTML('beforebegin', link);
+            frame.src = '';
+            frame.onload = () => document.getElementById('recap-download').click();
+            document.body = htmlBody;
+          } else {
+            let loadingMessage = document.getElementById('loading-message');
+            loadingMessage.remove();
+            document.body.insertAdjacentHTML('beforebegin', link);
+            document.getElementById('recap-download').click();
+          }
           history.pushState({ content: document.body.innerHTML }, '');
         }
       }

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -595,6 +595,32 @@ ContentDelegate.prototype.onDownloadAllSubmit = async function (event) {
   const browserSpecificFetch =
     navigator.userAgent.indexOf('Safari') + navigator.userAgent.indexOf('Chrome') < 0 ? content.fetch : window.fetch;
 
+  // load options
+  const options = await getItemsFromStorage('options');
+  // generate the filename
+  const pacerCaseId = event.data.id.match(/caseid\=\d*/)[0].replace(/caseid\=/, '');
+  const filename = generateFileName(options, pacerCaseId);
+
+  // show loading message
+  let mainDiv = document.getElementById('cmecfMainContent');
+  let loadingMessageWrapper = document.createElement('div');
+  loadingMessageWrapper.setAttribute('id', 'loading-message');
+  loadingMessageWrapper.style.textAlign = 'center';
+
+  const spinner = document.createElement('i');
+  spinner.classList.add('fa', 'fa-spinner', 'fa-spin');
+  spinner.setAttribute('id', 'recap-button-spinner');
+
+  let spanText = document.createElement('span');
+  spanText.style.fontFamily = 'helvetica,arial,serif';
+  spanText.style.fontSize = '13px';
+  spanText.style.padding = '0px 10px';
+  spanText.innerHTML = `Download in progress for file ${filename}`;
+
+  loadingMessageWrapper.appendChild(spinner);
+  loadingMessageWrapper.appendChild(spanText);
+  mainDiv.append(loadingMessageWrapper);
+
   // fetch the html page which contains the <iframe> link to the zip document.
   const htmlPage = await browserSpecificFetch(event.data.id).then((res) => res.text());
   const zipUrl = extractUrl(htmlPage);
@@ -610,12 +636,6 @@ ContentDelegate.prototype.onDownloadAllSubmit = async function (event) {
 
   // create the blob and inject it into the page
   const blobUrl = URL.createObjectURL(blob);
-  const pacerCaseId = event.data.id.match(/caseid\=\d*/)[0].replace(/caseid\=/, '');
-
-  // load options
-  const options = await getItemsFromStorage('options');
-  // generate the filename
-  const filename = generateFileName(options, pacerCaseId);
 
   if (options['recap_enabled'] && !this.restricted) {
     this.recap.uploadZipFile(


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/recap/issues/352 by tweaking the `extractUrl` method to retrieve the URL from the `script` tag. During the debugging process, I noticed the absence of a message indicating that the extension was uploading the zip file. To address this, I added a loading message on the page to inform users that the extension is working on the upload task.

Here's a GIF showing the new message:

![upload zip 2](https://github.com/freelawproject/recap-chrome/assets/55959657/98de8683-d773-4e82-88f9-8994cd7ab5e4)

### Additional comments

I couldn't reproduce the issue on Windows, it seems specific to macOS.