### PR TITLE
feat(content_delegate): Use the URL constructor to return absolute URL

### DIFF
--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -554,7 +554,10 @@ ContentDelegate.prototype.onDownloadAllSubmit = async function (event) {
       return null;
     }
     // Clean the match found in the HTML
-    return showTempURL[0].replace(';"', '');
+    let relativePath = showTempURL[0].replace(/\"|;/, '');
+
+    // Use absolute paths to avoid issue with Firefox.
+    return new URL(relativePath, window.location);
   };
 
   // helper function - convert string to html document


### PR DESCRIPTION
During QA testing, I discovered that the zip upload feature was failing in **Firefox** and displaying an error message indicating that the extracted URL from the response was invalid. Further investigation revealed a known issue with Firefox's handling of relative URLs. To resolve this issue, we should employ absolute URLs instead of relative ones.

Here’s the Firefox issue [#2647](https://github.com/greasemonkey/greasemonkey/issues/2647).


Once this PR is merged, We'll be ready to release a new version containing the fix for ZIP uploads.