### PR TITLE
Add additional appelate attachment page detection logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
  - None yet
 
 Fixes:
- - None yet
+ - Add additional appelate attachment page detection logic([#352](https://github.com/freelawproject/recap-chrome/pull/352))
 
 For developers:
  - Nothing yet

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -70,7 +70,11 @@ let APPELLATE = {
   // Returns true if this is a "Attachment page"
   isAttachmentPage: () => {
     let form = document.querySelector("form[name='dktEntry']");
-    return form !== null;
+    if (form !== null)
+      return true;
+    let table = document.getElementsByTagName("table");
+    let header = table.length ? table[0].getElementsByTagName("th") : false;
+    return (header && header.length) ? header[0].textContent.includes('Documents are attached to this filing') : false;
   },
 
   // Returns true if this is a "Download Confirmation page"


### PR DESCRIPTION
Seems some appellate court attachment pages aren't getting detected so lets add a fallback.