### PR TITLE
fix(style): Tweaks the src attribute to display icons properly

### DIFF
--- a/src/assets/css/style-ios.css
+++ b/src/assets/css/style-ios.css
@@ -23,8 +23,9 @@
 
 @font-face {
   font-family: 'RecapFontAwesome';
-  src: url("chrome-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2"), 
-  url("moz-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2");
+  src: url("chrome-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2"),
+  url("moz-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2"),
+  url("safari-web-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2");
   font-weight: normal;
   font-style: normal;
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -23,8 +23,9 @@
 
 @font-face {
   font-family: 'RecapFontAwesome';
-  src: url("chrome-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2"), 
-  url("moz-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2");
+  src: url("moz-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2"),
+  url("chrome-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2"),
+  url("safari-web-extension://__MSG_@@extension_id__/assets/fonts/fontawesome-webfont.woff2");
   font-weight: normal;
   font-style: normal;
 }


### PR DESCRIPTION
This PR implements a fix for broken icons encountered in Safari 17.2 and Firefox 120.0.1.