### PR TITLE
Hide UI recap-* UI elements from printed pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 The following changes are not yet released, but are code complete:
 
 Features:
- - None yet
+ - Hide recap UI elements from printed pages([#360](https://github.com/freelawproject/recap/issues/360), [#355](https://github.com/freelawproject/recap-chrome/pull/355)).
 
 Changes:
  - None yet

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -352,9 +352,9 @@ footer #version {
   border-top-left-radius: 0;
 }
 
-.btn-group .btn+.btn, 
-.btn-group .btn+.btn-group, 
-.btn-group .btn-group+.btn, 
+.btn-group .btn+.btn,
+.btn-group .btn+.btn-group,
+.btn-group .btn-group+.btn,
 .btn-group .btn-group+.btn-group {
   margin-left: -1px;
 }
@@ -492,11 +492,11 @@ footer #version {
 }
 
 .full-page-iframe{
-  position: absolute; 
-  left: 0; 
-  right: 0; 
-  bottom: 0; 
-  top: 0; 
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  top: 0;
 }
 
 .recap-inline-appellate{
@@ -520,4 +520,10 @@ footer #version {
 
 .banner-message > img{
   margin-right: 0.25rem;
+}
+
+@media print {
+  [class^="recap-"], [id^="recap-"] {
+    display: none;
+  }
 }

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -522,8 +522,9 @@ footer #version {
   margin-right: 0.25rem;
 }
 
+/* For printed pages, we want to hide anything that we add. */
 @media print {
-  [class^="recap-"], [id^="recap-"] {
+  [class^="recap-"], [id^="recap-"] { /* Any class or ID that starts with `recap-` */
     display: none;
   }
 }


### PR DESCRIPTION
This simple CSS tweak should hide all the elements that we add, as long as they start with a CSS class or ID of `recap-*`. I haven't used the extension enough to be able to tell if this catches everything, but in my casual tests, it hid all the UI elements I could find.

If we discover any that are missed, we should probably just add a `.recap-blahblah` class to them.