### PR TITLE
fix(options): Update newsletter link

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -188,7 +188,7 @@
           <i class="fa fa-circle fa-stack-2x gray"></i>
           <i class="fa fa-twitter fa-stack-1x fa-inverse"></i>
         </a>
-        <a href="https://free.law/newsletter/" class="fa-stack fa-lg" target="_blank" rel="noopener">
+        <a href="https://donate.free.law/np/clients/freelawproject/subscribe.jsp?subscription=9" class="fa-stack fa-lg" target="_blank" rel="noopener">
           <i class="fa fa-circle fa-stack-2x gray"></i>
           <i class="fa fa-newspaper-o fa-stack-1x fa-inverse"></i>
         </a>


### PR DESCRIPTION
Currently, the newsletter icon in the extension links to https://free.law/newsletter/ which is a 404. The /newsletter page appears to have been deleted and replaced in [this commit](https://github.com/freelawproject/free.law/commit/fbf845aee7d8fe59dbb9bfe375379d0e21f9087b) last month.

This PR updates the newsletter icon link to go https://donate.free.law/np/clients/freelawproject/subscribe.jsp?subscription=9 which is the same location as the footer on https://free.law.

Newsletter icon in the extension:
![The RECAP extension opened with the newsletter icon highlighted with a red box](https://github.com/freelawproject/recap-chrome/assets/29699850/93195257-aae6-4d8d-a5cb-5b2158f1c674)

How https://free.law/newsletter/ currently appears:
![404 on the free.law website](https://github.com/freelawproject/recap-chrome/assets/29699850/daa093d3-fbfa-468b-9b62-c71e4b4c57e7)