### PR TITLE
Fix setBadgeText type error

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Features:
 
 Changes:
  - Adds a badge to the extension icon and a banner in the popup to link users to a donate page with information about the pacer class action([#367](https://github.com/freelawproject/recap/issues/367), [#364](https://github.com/freelawproject/recap-chrome/pull/364)).
+ - Fix setBadgeText type error([#366](https://github.com/freelawproject/recap-chrome/pull/366)).
 
 Fixes:
  - None yet

--- a/src/toolbar_button.js
+++ b/src/toolbar_button.js
@@ -30,7 +30,7 @@ function updateToolbarButton(tab) {
   chrome.storage.local.get('options', function(items){
 
     if ('dismiss_bagde' in items['options'] && items['options']['dismiss_bagde']) {
-      chrome.browserAction.setBadgeText({});
+      chrome.browserAction.setBadgeText({ text: '' });
     } else {
       chrome.browserAction.setBadgeText({ text: '🎁' });
     }


### PR DESCRIPTION
Fixes:
```js
Error: Type error for parameter details (Property "text" is required) for browserAction.setBadgeText.
```