### PR TITLE
fix(popup): Adjust header spacing in popup window

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -9,7 +9,7 @@
 </head>
 
 <body id="options-body">
-  <div id="container" class="grid-with-banner">
+  <div id="container" class="regular-grid">
     <!-- Main Tab Content + Donation plea -->
     <header>
       <div class="d-flex flex-column">


### PR DESCRIPTION
This PR adjusts the spacing of the header element within the popup window. In a previous PR (#368), we removed the HTML elements of the old banner but forgot to update the corresponding CSS class that sets the header height.