### PR TITLE
feat(acms): Adds helper method to handle the Download Confirmation Page

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -7,6 +7,7 @@ The following changes are not yet released, but are code complete:
 Features:
  - Introduces a new upload type for Dockets from ACMS and enhances code maintainability by refactoring common upload logic into reusable functions.([#368](https://github.com/freelawproject/recap-chrome/pull/371))
  - Docket reports from ACMS are now uploaded to CourtListener.([#372](https://github.com/freelawproject/recap-chrome/pull/372))
+ - Adds logic to upload ACMS PDF documents to CourtListener. ([#373](https://github.com/freelawproject/recap-chrome/pull/373))
 
 Changes:
  - None yet

--- a/spec/AppellateSpec.js
+++ b/spec/AppellateSpec.js
@@ -58,6 +58,35 @@ describe('The Appellate module', function () {
     });
   });
 
+  describe('parseReceiptPageTitle', function () {
+    it('parses title from download page', function () {
+      let titleData = APPELLATE.parseReceiptPageTitle(
+        'Document: PDF Document (Case: 22-11187, Document: 49)'
+      );
+      expect(titleData.docket_number).toBe('22-11187');
+      expect(titleData.doc_number).toBe('49');
+      expect(titleData.att_number).toBe(0);
+    });
+
+    it('parses title with attachment number from download page', function () {
+      let titleData = APPELLATE.parseReceiptPageTitle(
+        'Document: PDF Document (Case: 22-11187, Document: 43-1)'
+      );
+      expect(titleData.docket_number).toBe('22-11187');
+      expect(titleData.doc_number).toBe('43');
+      expect(titleData.att_number).toBe('1');
+    });
+
+    it('parses title from ACMS download page', function () {
+      let titleData = APPELLATE.parseReceiptPageTitle(
+        'Document: PDF Document (Case: 23-2487, Document: 3.1)'
+      );
+      expect(titleData.docket_number).toBe('23-2487');
+      expect(titleData.doc_number).toBe('3');
+      expect(titleData.att_number).toBe('1');
+    });
+  });
+
   describe('getServletFromInputs', function () {
     describe('for pages with matching format', function () {
       beforeEach(function () {

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -1102,10 +1102,20 @@ describe('The ContentDelegate class', function () {
           },
         },
       };
-      spyOn(cd.recap, 'uploadDocument').and.callFake((court, caseId, docId, docNumber, attachNumber, callback) => {
-        callback.tab = { id: 1234 };
-        callback(true);
-      });
+      spyOn(cd.recap, 'uploadDocument').and.callFake(
+        (
+          court,
+          caseId,
+          docId,
+          docNumber,
+          attachNumber,
+          acmsDocumentGuid,
+          callback
+        ) => {
+          callback.tab = { id: 1234 };
+          callback(true);
+        }
+      );
       document.getElementById = jasmine.createSpy('getElementById').and.callFake((id) => {
         return document.querySelectorAll(`#${id}`)[0];
       });

--- a/spec/RecapSpec.js
+++ b/spec/RecapSpec.js
@@ -218,7 +218,15 @@ describe('The Recap export module', function () {
       existingFormData = window.FormData;
       window.FormData = FormDataFake;
       spyOn(recap, 'uploadDocument').and.callFake(
-        (court, case_id, doc_id, doc_number, attach_number, cb) => {
+        (
+          court,
+          case_id,
+          doc_id,
+          doc_number,
+          attach_number,
+          acmsDocumentGuid,
+          cb
+        ) => {
           cb(true);
         }
       );
@@ -245,8 +253,14 @@ describe('The Recap export module', function () {
       expected.append('filepath_local', blob);
 
       await recap.uploadDocument(
-        court, pacer_case_id, pacer_doc_id, docnum, attachnum,
-        callback);
+        court,
+        pacer_case_id,
+        pacer_doc_id,
+        docnum,
+        attachnum,
+        null,
+        callback
+      );
       expect(callback).toHaveBeenCalledWith(true);
     });
   });
@@ -288,7 +302,6 @@ describe('The Recap export module', function () {
 
   describe('uploadIQueryPage', function (){
     let existingFormData;
-    
     beforeEach(async () => {
       existingFormData = window.FormData;
       window.FormData = FormDataFake;

--- a/src/appellate/acms_api.js
+++ b/src/appellate/acms_api.js
@@ -1,4 +1,13 @@
 function Acms() {
+  // Asynchronously checks the progress of the PDF link generation using a
+  // provided URL and authorization token.
+  // This function fetches data from the specified URL using a GET request with
+  // an Authorization header containing a Bearer token. It then parses the JSON
+  // response and throws an error if the request fails (status code is not 200).
+  // Otherwise, it returns the parsed JSON data.
+  //
+  // returns A promise that resolves to the parsed JSON data
+  // on success, or rejects with an error if the request fails.
   async function checkProgress(url, token) {
     const response = await fetch(url, {
       headers: { Authorization: `Bearer ${token}` },
@@ -12,6 +21,17 @@ function Acms() {
     return data;
   }
 
+  // Asynchronously submits data to a server using a POST request.
+  // This function sends a POST request to the specified URL with an
+  // authorization token and the provided data.
+  // The data is expected to be a JavaScript object and will be converted
+  // to format before sending and The Authorization header includes a Bearer
+  // token for authentication. The function parses the JSON response and
+  // throws an error if the request fails (status code is not 200 OK).
+  // Otherwise, it returns the parsed JSON data.
+  //
+  // Returns A promise that resolves to the parsed JSON data on success, or
+  // rejects with an error if the request fails.
   async function postData(url, token, body = {}) {
     const response = await fetch(url, {
       method: 'POST',
@@ -30,6 +50,24 @@ function Acms() {
     return data;
   }
 
+  // This function simulates a while loop using Promises. It takes three
+  // arguments:
+  //  - `input`: The initial value for the loop.
+  //  - `condition`: A function that evaluates to true as long as the loop
+  //     should continue.
+  //  - `action`: A function that returns a Promise and performs the loop's
+  //     logic for each iteration.
+  //
+  // It returns a Promise that resolves with the final `input` value when the
+  // `condition` function becomes false.
+  //
+  // It works by defining a recursive helper function `whilst`. This function
+  // checks the `condition` on the current `input`.
+  //  - If `condition` is true, it calls the `action` function with `input`.
+  //    The result (a Promise) is then chained with another call to `whilst`,
+  //    effectively continuing the loop.
+  //  - If `condition` is false, it resolves the returned Promise immediately
+  //    with the current `input` value, signifying the end of the loop.
   const promiseWhile = (input, condition, action) => {
     const whilst = (input) =>
       condition(input) ? action(input).then(whilst) : Promise.resolve(input);
@@ -44,18 +82,26 @@ function Acms() {
 
       const statusQueryUrl = data && data.statusQueryGetUri;
 
+      // Prepare elements to be used within the promiseWhile loop.
+      // Helper function to check if the job is completed based on a
+      // given status
       const isCompleted = (status) => /Completed/i.test(status);
+      // Helper function to determine if we should continue checking
       const condition = (runtimeStatus) => !isCompleted(runtimeStatus);
+      // Initial runtime status (empty string)
       const initialRuntimeStatus = '';
 
+      // Function to perform a single check on the job progress
       const action = (runtimeStatus) =>
         new Promise((resolve, reject) => {
           checkProgress(statusQueryUrl, token)
             .then((response) => {
+              // Extract the new runtime status from the response (if it exists)
               const newRuntimeStatus = response && response.runtimeStatus;
 
               if (!newRuntimeStatus) reject('No runtime status was returned.');
 
+              // Update the output variable if the job is completed
               if (isCompleted(newRuntimeStatus))
                 output = response && response.output;
 
@@ -66,6 +112,7 @@ function Acms() {
             });
         });
 
+      // Use promiseWhile to keep checking the status until the job is completed
       let fileGuid = await promiseWhile(
         initialRuntimeStatus,
         condition,

--- a/src/appellate/acms_api.js
+++ b/src/appellate/acms_api.js
@@ -1,0 +1,77 @@
+function Acms() {
+  async function checkProgress(url, token) {
+    const response = await fetch(url, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+
+    const data = await response.json();
+
+    if (!response.ok)
+      throw new Error(`Error attempting to fetch with checkProgress: ${data}`);
+
+    return data;
+  }
+
+  async function postData(url, token, body = {}) {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+
+    const data = await response.json();
+
+    if (!response.ok)
+      throw new Error(`Error attempting to fetch with postData: ${data}`);
+
+    return data;
+  }
+
+  const promiseWhile = (input, condition, action) => {
+    const whilst = (input) =>
+      condition(input) ? action(input).then(whilst) : Promise.resolve(input);
+    return whilst(input);
+  };
+
+  return {
+    // Use the ACMS API to retrieve the file GUID and compute the document URL
+    getDocumentURL: async function (apiUrl, token, mergePdfFilesRequest, cb) {
+      const url = `${apiUrl}/MergePDFFiles`;
+      const data = await postData(url, token, mergePdfFilesRequest);
+
+      const statusQueryUrl = data && data.statusQueryGetUri;
+
+      const isCompleted = (status) => /Completed/i.test(status);
+      const condition = (runtimeStatus) => !isCompleted(runtimeStatus);
+      const initialRuntimeStatus = '';
+
+      const action = (runtimeStatus) =>
+        new Promise((resolve, reject) => {
+          checkProgress(statusQueryUrl, token)
+            .then((response) => {
+              const newRuntimeStatus = response && response.runtimeStatus;
+
+              if (!newRuntimeStatus) reject('No runtime status was returned.');
+
+              if (isCompleted(newRuntimeStatus))
+                output = response && response.output;
+
+              resolve(newRuntimeStatus);
+            })
+            .catch((error) => {
+              console.log(error);
+            });
+        });
+
+      let fileGuid = await promiseWhile(
+        initialRuntimeStatus,
+        condition,
+        action
+      ).then((status) => output);
+      cb(`${apiUrl}/GetMergedFile?fileGuid=${fileGuid}`);
+    },
+  };
+}

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -181,6 +181,27 @@ AppellateDelegate.prototype.handleAcmsDownloadPage = async function () {
             'click',
             startUploadProcess.bind(this)
           );
+
+          // Query the server to check the availability of the document in the
+          // RECAP archive.
+          this.recap.getAvailabilityForDocuments(
+            [this.docId],
+            this.court,
+            (api_results) => {
+              console.info(
+                'RECAP: Got results from API. Running callback on API ' +
+                  'results to insert banner'
+              );
+              let result = api_results.results.filter(
+                (obj) => obj.pacer_doc_id == this.docId,
+                this
+              )[0];
+              if (!result) {
+                return;
+              }
+              insertAvailableDocBanner(result.filepath_local, 'div.box');
+            }
+          );
         }
       };
     };

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -134,6 +134,37 @@ AppellateDelegate.prototype.handleAcmsDocket = async function () {
 AppellateDelegate.prototype.handleAcmsDownloadPage = async function () {
 
   async function startUploadProcess() {
+    // This function initiates the upload process for a PDF document.
+    // It performs the following steps:
+    //
+    // 1. Prepares data for upload:
+    //    - Parses download data from session storage and creates a request
+    //      body for the PDF URL document.
+    //
+    // 2. Retrieves configuration and tokens:
+    //    - Extracts API URL and token from session storage stored in
+    //      the 'recapACMSConfiguration' key.
+    //
+    // 3. Extracts document information:
+    //    - Extracts title from the element with class 'p.font-weight-bold'.
+    //    - Parses relevant details (att_number) from the title.
+    //    - Builds a documentData object containing docket number, document
+    //      number, and attachment number.
+    //
+    // 4. Adds a loading message:
+    //    - Creates a loading message using APPELLATE.createsLoadingMessage.
+    //
+    // 5. Stores case ID and document GUID (assumed for later use):
+    //    - Saves case ID from download data.
+    //    - Saves document GUID from download data.
+    //
+    // 6. Gets PDF download URL and initiates download:
+    //    - Stores the current page HTML content.
+    //    - Calls acms.getDocumentURL to get the PDF download URL.
+    //    - Once the URL is retrieved, initiates an HTTP request to download
+    //      the PDF.
+    //    - Binds the handleDocFormResponse function to handle the downloaded
+    //      data and document information after download completes.
     let downloadData = JSON.parse(
       sessionStorage.getItem('recapVueData')
     );

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -50,7 +50,9 @@ AppellateDelegate.prototype.regularAppellatePageHandler = function () {
 };
 
 AppellateDelegate.prototype.ACMSPageHandler = function () {
-  if (this.path.match(/^\/[0-9\-]+$/)) {
+  if (this.path.startsWith('/download-confirmation/')) {
+    this.handleAcmsDownloadPage();
+  } else if (this.path.match(/^\/[0-9\-]+$/)) {
     this.handleAcmsDocket();
   }
 };
@@ -126,6 +128,10 @@ AppellateDelegate.prototype.handleAcmsDocket = async function () {
   const body = document.querySelector('body');
   const observer = new MutationObserver(footerObserver);
   observer.observe(body, { subtree: true, childList: true });
+};
+
+AppellateDelegate.prototype.handleAcmsDownloadPage = async function () {
+  //pass
 };
 
 AppellateDelegate.prototype.handleCaseSearchPage = () => {

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -6,6 +6,7 @@ let AppellateDelegate = function (tabId, court, url, path, links) {
   this.path = path;
   this.links = links || [];
   this.recap = importInstance(Recap);
+  this.acms = importInstance(Acms);
   this.notifier = importInstance(Notifier);
   this.queryParameters = APPELLATE.getQueryParameters(this.url);
   this.docId = APPELLATE.getDocIdFromURL(this.queryParameters);

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -450,4 +450,35 @@ let APPELLATE = {
     // this tag.
     script.remove();
   },
+
+  // Extract data needed to construct the PDF request body
+  createAcmsDocumentRequestBody: function (downloadData) {
+    let queryParameters = new URLSearchParams(window.location.search);
+    let includePageNumbers = !!queryParameters.get('includePageNumbers');
+    let showPDFHeaderInput = document.getElementById('showPdfHeader').checked;
+
+    const pdfItemMapping = (data) => ({
+      acms_docketdocumentdetailsid: data && data.docketDocumentDetailsId,
+      acms_name: data && data.name,
+      acms_documenturl: data && data.documentUrl,
+      acms_casefilingdocumenturl: data && data.caseFilingDocumentUrl,
+      acms_documentpermission: data && data.documentPermission,
+      acms_pagecount: data && data.pageCount,
+      acms_filesize: data && data.fileSize,
+      billablepages: data && data.billablePages,
+      cost: data && data.cost,
+      acms_documentnumber: data && data.documentNumber,
+      searchValue: data && data.searchValue,
+      searchTransaction: data && data.searchTransaction,
+    });
+
+    return {
+      mergeScope: 'External',
+      pagination: includePageNumbers,
+      header: showPDFHeaderInput,
+      docketEntryDocuments: downloadData.docketEntryDocuments.map((data) =>
+        pdfItemMapping(data)
+      ),
+    };
+  }
 };

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -424,6 +424,13 @@ let APPELLATE = {
 
   // Adds the vue data attributes to the session storage
   storeVueDataInSession: () => {
+    // The following code draws inspiration from the Vue devtool extension
+    // to identify and inspect Vue components within a web application.
+    // Unlike the devtool extension, which explores the entire DOM, this script
+    // focuses on extracting the data of the main Vue component. By tailoring
+    // the script to the component's HTML structure, we achieve a quick data
+    // retrieval process compared to a full DOM exploration.
+    // The extracted data is then stored in session storage for later use.
     var code =
       '(' +
       function () {
@@ -451,7 +458,26 @@ let APPELLATE = {
     script.remove();
   },
 
-  // Extract data needed to construct the PDF request body
+  // Prepares the body to request a PDF document link
+  // It takes the `downloadData` object as input, which is expected to contain
+  // information about the documents to be included in the link
+  // The function performs the following actions:
+  // 1. Extracts query parameters from the URL to determine if page numbers
+  //    should be included.
+  // 2. Gets the value from the 'showPdfHeader' checkbox to determine if a
+  //    header should be included in the PDF.
+  // 3. Defines a helper function `pdfItemMapping` that extracts relevant data
+  //    from each document in `downloadData.docketEntryDocuments`.
+  // 4. Constructs the request body object with the following properties:
+  //     - `mergeScope`: Set to 'External' as these are external documents.
+  //     - `pagination`: Set to the value of `includePageNumbers` for including
+  //        page numbers.
+  //     - `header`: Set to the value of `showPDFHeaderInput` for including a
+  //        header.
+  //     - `docketEntryDocuments`: An array of objects containing mapped
+  //        document details using `pdfItemMapping`.
+  //
+  // This function returns the constructed request body object.
   createAcmsDocumentRequestBody: function (downloadData) {
     let queryParameters = new URLSearchParams(window.location.search);
     let includePageNumbers = !!queryParameters.get('includePageNumbers');

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -333,21 +333,32 @@ let APPELLATE = {
 
   // returns data from the title of the Receipt Page as an object
   parseReceiptPageTitle: (title_string) => {
-    // The title in the Download Confirmation page from Appellate pacer shows useful information about the document.
-    // this title has the docket number, document number and the attachment number (if the document belongs to an attachment
-    // page). Here are some examples:
+    // The title in the Download Confirmation page from Appellate pacer shows
+    // useful information about the document. This title has the docket number,
+    // document number and the attachment number (if the document belongs to an
+    // attachment page). Here are some examples:
     //
     //  - Document: PDF Document (Case: 20-15019, Document: 11)
-    //  - Document: PDF Document (Case: 20-15019, Document: 1-1) (document from attachment page)
+    //  - Document: PDF Document (Case: 20-15019, Document: 1-1) (document
+    //    from attachment page)
+    //  - Document: PDF Document (Case: 20-15019, Document: 1.1) (document
+    //    from ACMS)
     //
-    // this method uses regex expressions to match that information from the title and returns an object with the following
-    // attributes:
+    // this method uses regex expressions to match that information from the
+    // title and returns an object with the following attributes:
     //  - docket_number
     //  - doc_number
     //  - att_number
 
-    let dataFromAttachment = /^Document: PDF Document \(Case: ([^']*), Document: (\d+)-(\d+)\)/.exec(title_string);
-    let dataFromSingleDoc = /^Document: PDF Document \(Case: ([^']*), Document: (\d+)\)/.exec(title_string);
+    let dataFromAttachment =
+      /^Document: PDF Document \(Case: ([^']*), Document: (\d+)[-.]+(\d+)\)/.exec(
+        title_string
+      );
+    let dataFromSingleDoc =
+      /^Document: PDF Document \(Case: ([^']*), Document: (\d+)\)/.exec(
+        title_string
+      );
+
     if (!dataFromAttachment && !dataFromSingleDoc) {
       return null;
     }

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -410,4 +410,33 @@ let APPELLATE = {
 
     return recap_div;
   },
+
+  // Adds the vue data attributes to the session storage
+  storeVueDataInSession: () => {
+    var code =
+      '(' +
+      function () {
+        let contentWrapper = document.getElementsByClassName('text-center')[0];
+        let vueMainDiv = contentWrapper.parentElement;
+        let vueDataProperties = vueMainDiv.__vue__._data;
+        sessionStorage.setItem(
+          'recapVueData',
+          JSON.stringify(vueDataProperties)
+        );
+        sessionStorage.setItem(
+          'recapACMSConfiguration',
+          JSON.stringify(window._model)
+        );
+      } +
+      ')();';
+
+    let script = document.createElement('script');
+    script.textContent = code;
+    document.head.appendChild(script);
+
+    // We just need this script once and the inline script that's inserted in
+    // the document is immediately executed. Therefore, it's safe to remove
+    // this tag.
+    script.remove();
+  },
 };

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -480,5 +480,25 @@ let APPELLATE = {
         pdfItemMapping(data)
       ),
     };
-  }
+  },
+
+  // Creates a div with a spinner and a loading message
+  createsLoadingMessage: (downloadData) => {
+    let loadingTextDiv = document.createElement('div');
+    loadingTextDiv.classList.add('box', 'mt-2');
+
+    let loadingTextElement = document.createElement('h4');
+    loadingTextElement.classList.add('text-center', 'mt-0');
+    let spinner = document.createElement('i');
+    spinner.classList.add('mdi', 'mdi-spin', 'mdi-loading', 'mr-2');
+    let spanText = document.createElement('span');
+    spanText.innerHTML =
+      'Download in progress for case number ' +
+      `${downloadData.caseSummary.caseDetails.caseNumber}`;
+
+    loadingTextElement.appendChild(spinner);
+    loadingTextElement.appendChild(spanText);
+    loadingTextDiv.appendChild(loadingTextElement);
+    return loadingTextDiv;
+  },
 };

--- a/src/background.js
+++ b/src/background.js
@@ -188,8 +188,9 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
       options.pacer_doc_id,
       options.document_number,
       options.attachment_number,
+      'acmsDocumentGuid' in options ? options.acmsDocumentGuid : null,
       callback
-    )
+    );
   }
 });
 

--- a/src/background.js
+++ b/src/background.js
@@ -3,6 +3,7 @@
 // Make services callable from content scripts.
 exportInstance(Notifier);
 exportInstance(Recap);
+exportInstance(Acms);
 
 function chooseVariant(details) {
   const options = ['A-A', 'A-C', 'B-B', 'B-D'];
@@ -159,6 +160,7 @@ async function injectContentScript(tabId, status, url) {
           { file: 'content_delegate.js'},
           { file: 'appellate/utils.js'},
           { file: 'appellate/appellate.js'},
+          { file: 'appellate/acms_api.js'},
           { file: 'content.js'},
       ])
       }

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -92,8 +92,8 @@
     ]
   },
   "content_scripts": [{
-    "matches": ["*://*.uscourts.gov/*"],
-    "include_globs": ["*://ecf.*", "*://ecf-train.*", "*://pacer.*"],
+    "matches": ["*://*.uscourts.gov/*", "*://*.azurewebsites.us/*"],
+    "include_globs": ["*://ecf.*", "*://ecf-train.*", "*://pacer.*", "*://*-showdoc.*"],
     "css": [
       "assets/css/style.css",
       "assets/css/font-awesome.css"

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -88,6 +88,7 @@
       "toolbar_button.js",
       "pacer.js",
       "recap.js",
+      "appellate/acms_api.js",
       "background.js"
     ]
   },

--- a/src/pdf_upload.js
+++ b/src/pdf_upload.js
@@ -206,12 +206,23 @@ const showAndUploadPdf = async function (
     // If we have the pacer_case_id, upload the file to RECAP.
     // We can't pass an ArrayBuffer directly to the background
     // page, so we have to convert to a regular array.
-    this.recap.uploadDocument(this.court, pacer_case_id, pacer_doc_id, document_number, attachment_number, (ok) => {
-      // callback
-      if (ok) {
-        this.notifier.showUpload('PDF uploaded to the public RECAP Archive.', () => {});
+    this.recap.uploadDocument(
+      this.court,
+      pacer_case_id,
+      pacer_doc_id,
+      document_number,
+      attachment_number,
+      this.acmsDocumentGuid,
+      (ok) => {
+        // callback
+        if (ok) {
+          this.notifier.showUpload(
+            'PDF uploaded to the public RECAP Archive.',
+            () => {}
+          );
+        }
       }
-    });
+    );
   } else {
     console.info('RECAP: Not uploading PDF. RECAP is disabled.');
   }

--- a/src/recap.js
+++ b/src/recap.js
@@ -195,6 +195,7 @@ function Recap() {
       document_guid = null,
       cb
     ) => {
+      // Construct a summary message for logging upload data to RECAP Archive
       let uploadDataSummary = [
         'RECAP: Attempting PDF upload to RECAP Archive with details:',
         `pacer_court: ${pacer_court}`,

--- a/src/recap.js
+++ b/src/recap.js
@@ -192,16 +192,21 @@ function Recap() {
       pacer_doc_id,
       document_number,
       attachment_number,
+      document_guid = null,
       cb
     ) => {
-      console.info([
+      let uploadDataSummary = [
         'RECAP: Attempting PDF upload to RECAP Archive with details:',
         `pacer_court: ${pacer_court}`,
         `pacer_case_id: ${pacer_case_id}`,
         `pacer_doc_id: ${pacer_doc_id}`,
         `document_number: ${document_number},`,
-        `attachment_number: ${attachment_number}.`
-      ].join(' '));
+        `attachment_number: ${attachment_number},`,
+      ];
+      if (document_guid) {
+        uploadDataSummary.push(`document_guid: ${document_guid}.`);
+      }
+      console.info(uploadDataSummary.join(' '));
 
       // extract the tabId from the enhanced callback
       // wait for chrome.storage.local to load the tabStorage
@@ -217,6 +222,9 @@ function Recap() {
             formData.append('document_number', document_number);
           if (attachment_number && attachment_number !== '0') {
             formData.append('attachment_number', attachment_number);
+          }
+          if (document_guid) {
+            formData.append('acms_document_guid', document_guid);
           }
           return formData;
         })


### PR DESCRIPTION
This PR adds support to upload documents from the new ACMS website and inserts a banner that lets users know a matching record is available in the RECAP archive.

The PR introduces the following changes:

- Refines the `dispatchHandler` method to effectively manage the **Download confirmation page**. The extension uses the `path` property for page identification.

- Uses the [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver) interface to monitor DOM changes and ensure all elements are rendered before proceeding. This PR removes the default `onclick` event of the **"Accept Charges"** button and replaces it with a custom event handler that allows us to upload documents to the RECAP archive.

- The Appellate class uses the ACMS API to retrieve the pdf documents so the PR adds a new file named `acms_api.js` to encapsulate utility functions designed to handle API interactions. I used the `exportInstance()` and `importInstance()` methods to enable the communication between the content script and the new service.

- Enhances the `parseReceiptPageTitle` method by refining the regular expressions to extract the data from the title of the download confirmation page. 

- Introduces a new helper function named `storeVueDataInSession` that extracts the app settings( API data and Auth token) and the data used by Vue to render the page and stores it in the `sessionStorage` object, allowing the extension access to the same data.

- Add a new parameter to the `uploadDocument` function so we can send the ACMS document GUI when it's available. 

Here's a gif showing how the extension works:

![Screen Recording 2024-05-01 at 9 06 50 AM](https://github.com/freelawproject/recap-chrome/assets/55959657/0cfad35a-e2c9-4370-ad2d-30b75756001a)

and the banner looks like this: 

![image](https://github.com/freelawproject/recap-chrome/assets/55959657/51b8fcb7-bf76-4d34-9e14-b8f0165758a0)
