### PR TITLE
feat(acms): Adds support to upload ACMS attachment pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Features:
  - Docket reports from ACMS are now uploaded to CourtListener.([#372](https://github.com/freelawproject/recap-chrome/pull/372))
  - Adds logic to upload ACMS PDF documents to CourtListener. ([#373](https://github.com/freelawproject/recap-chrome/pull/373))
  - Inserts the RECAP button and [R] icons to the ACMS Docket report. ([#374](https://github.com/freelawproject/recap-chrome/pull/374))
+ - Introduces logic to upload ACMS attachment pages to CourtListener([#375](https://github.com/freelawproject/recap-chrome/pull/375))
 
 Changes:
  - None yet

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -88,16 +88,18 @@ AppellateDelegate.prototype.handleAcmsAttachmentPage = async function () {
         JSON.stringify(requestBody),
         'ACMS_ATTACHMENT_PAGE',
         (ok) => {
-          console.log('in cb');
           if (ok) {
-            console.log('cb success');
             history.replaceState({ uploaded: true }, '');
             this.notifier.showUpload(
               'Attachment page uploaded to the public RECAP Archive.',
               () => {}
             );
-          } else {
-            console.log('cb fail');
+          }else {
+            this.notifier.showUpload(
+              'Error: The Attachment page was not uploaded to the public' +
+                'RECAP Archive',
+              () => {}
+            );
           }
         }
       );

--- a/src/recap.js
+++ b/src/recap.js
@@ -17,6 +17,7 @@ function Recap() {
       'CASE_QUERY_RESULT_PAGE': 14,
       'APPELLATE_CASE_QUERY_RESULT_PAGE': 15,
       'ACMS_DOCKET_JSON': 16,
+      'ACMS_ATTACHMENT_PAGE': 17,
     };
 
   function _buildForm(


### PR DESCRIPTION
This PR introduces a new upload type for attachment pages from ACMS('ACMS_ATTACHMENT_PAGE': 17) and adds a new method `handleAcmsAttachmentPage` to the `AppellateDelegate` class specifically for handling attachment pages uploads from ACMS.

This PR depends on https://github.com/freelawproject/courtlistener/pull/3393.

Here's a gif showing how the extension works:

![cropped video](https://github.com/freelawproject/recap-chrome/assets/55959657/086518b7-a465-465b-9812-72c174826a17)

