### PR TITLE
feat(acms): Adds logic to display the warning about combined PDFs

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,6 +9,7 @@ Features:
  - Docket reports from ACMS are now uploaded to CourtListener.([#372](https://github.com/freelawproject/recap-chrome/pull/372))
  - Adds logic to upload ACMS PDF documents to CourtListener. ([#373](https://github.com/freelawproject/recap-chrome/pull/373))
  - Inserts the RECAP button and [R] icons to the ACMS Docket report. ([#374](https://github.com/freelawproject/recap-chrome/pull/374))
+ - Displays the warning about combined PDFs on the download page.([#376](https://github.com/freelawproject/recap-chrome/pull/376))
 
 Changes:
  - None yet

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -375,7 +375,22 @@ AppellateDelegate.prototype.handleAcmsDownloadPage = async function () {
           .toLowerCase()
           .includes('accept charges and retrieve');
 
-        if (n.localName === 'div' && hasReceipt && hasAcceptChargesButton) {
+        let hasOneDocument = JSON.parse(
+          sessionStorage.selectedDocuments
+        ).length == 1;
+
+        if (
+          n.localName === 'div' &&
+          hasReceipt &&
+          hasAcceptChargesButton
+        ) {
+
+          if (!hasOneDocument){
+            pdfWarning = combinedPdfWarning();
+            n.append(pdfWarning);
+            return;
+          }
+
           // Insert script to retrieve and store Vue data in the storage
           APPELLATE.storeVueDataInSession();
 

--- a/src/assets/css/style.css
+++ b/src/assets/css/style.css
@@ -196,6 +196,12 @@ footer #version {
   font-size: 13px;
 }
 
+.recap-combined-pdf-text {
+  display: flex;
+  align-content: center;
+  text-align: justify;
+}
+
 .recap-banner,
 .recap-popup,
 .recap-email-banner {

--- a/src/utils.js
+++ b/src/utils.js
@@ -424,11 +424,13 @@ const combinedPdfWarning = () => {
   imgDiv.appendChild(img);
 
   let text = document.createElement('p');
-  text.innerHTML = `This document <b>will not be uploaded</b> to the RECAP Archive because the extension has detected that this page may return a combined PDF and consistently splitting these files in a proper manner is not possible for now.`;
+  text.innerHTML = 'This document <b>will not be uploaded</b> to the RECAP'
+    + 'Archive because the extension has detected that this page may return'
+    + 'a combined PDF and consistently splitting these files in a proper manner'
+    + 'is not possible for now.';
 
   let messageDiv = document.createElement('div');
-  messageDiv.style.display = 'flex';
-  messageDiv.style.alignContent = 'center';
+  messageDiv.classList.add('recap-combined-pdf-text');
   messageDiv.appendChild(text);
 
   let innerDiv = document.createElement('div');


### PR DESCRIPTION
This PR adds logic to check the number of documents on the download page and display the warning about combined PDFs when there's more than one.

![Screen Recording 2024-05-27 at 5 58 33 PM](https://github.com/freelawproject/recap-chrome/assets/55959657/6a18a240-0b9f-476b-9768-b41abb824db0)
