### PR TITLE
fix(pacer): Prevents error by checking filingCookie existence

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,7 @@ Features:
  - Inserts the RECAP button and [R] icons to the ACMS Docket report. ([#374](https://github.com/freelawproject/recap-chrome/pull/374))
  - Displays the warning about combined PDFs on the download page.([#376](https://github.com/freelawproject/recap-chrome/pull/376))
  - Introduces logic to upload ACMS attachment pages to CourtListener([#375](https://github.com/freelawproject/recap-chrome/pull/375))
+ - Introduces validation for the cookie used to identify filing account users.([#371](https://github.com/freelawproject/recap/issues/371), [#377](https://github.com/freelawproject/recap-chrome/pull/377)).
 
 Changes:
  - Updates style and replace old logos with new ones([#378](https://github.com/freelawproject/recap-chrome/pull/378))

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -581,6 +581,31 @@ describe('The PACER module', function () {
     });
   });
 
+  describe('hasFilingCookie', function () {
+    const filingAccountCookie =
+      'PacerSession=B7yuvmcj2F...9p5nDzEXsHE; ' + 'isFilingAccount=true';
+    const nonFilingAccountCookie =
+      'PacerUser=B7yuvmcj2F...9p5nDzEXsHE; ' + 'PacerPref=receipt=Y';
+    const nonLoggedInCookie = 'PacerSession=unvalidated; PacerPref=receipt=Y';
+    const nonsenseCookie = 'Foo=barbaz; Baz=bazbar; Foobar=Foobar';
+
+    it('returns true for a valid cookie from a filing account', function () {
+      expect(PACER.hasFilingCookie(filingAccountCookie)).toBe(true);
+    });
+
+    it('returns false for cookies from a non-filing account', function () {
+      expect(PACER.hasFilingCookie(nonFilingAccountCookie)).toBe(false);
+    });
+
+    it('returns false for a non-logged in cookie', function () {
+      expect(PACER.hasFilingCookie(nonLoggedInCookie)).toBe(false);
+    });
+
+    it('returns false for nonsense cookie', function () {
+      expect(PACER.hasFilingCookie(nonsenseCookie)).toBe(false);
+    });
+  });
+
   describe('isAppellateCourt', function () {
     it('returns true for an appellate court', function () {
       expect(PACER.isAppellateCourt('ca5')).toBe(true);

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -606,7 +606,7 @@ let PACER = {
     let filingCookie = cookieString.split('; ')
         .find((row) => row.startsWith('isFilingAccount'))
         ?.split('=')[1];
-    return !!filingCookie.match(/true/);
+    return !!(filingCookie && filingCookie.match(/true/));
   },
 
   // Returns true if the given court identifier is for an appellate court.


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/recap/issues/371 by checking the `filingCookie` variable before accessing its value. I also added tests to ensure the fix works as expected and prevent regressions in the future.