### PR TITLE
feat(toolbar): Adds custom badge for Safari

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,7 +15,7 @@ Features:
 
 Changes:
  - Updates style and replace old logos with new ones([#378](https://github.com/freelawproject/recap-chrome/pull/378))
- - Adds a badge to the extension icon and a banner in the options menu([#379](https://github.com/freelawproject/recap-chrome/pull/379))
+ - Adds a badge to the extension icon and a banner in the options menu([#379](https://github.com/freelawproject/recap-chrome/pull/379), [#380](https://github.com/freelawproject/recap-chrome/pull/380))
 
 Fixes:
  - None yet

--- a/src/background.js
+++ b/src/background.js
@@ -172,6 +172,12 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
   if (msg.message === 'requestTabId') {
     sendResponse({ tabId: sender.tab.id });
   }
+  if (msg.message === 'clearBadge') {
+    chrome.storage.local.get('options', function (items) {
+      items.options['dismiss_news_badge'] = true;
+      saveOptionsAndUpdateToolbar(items.options);
+    });
+  }
   if (msg.message === 'upload'){
     let recap = new Recap();
     let notifier = new Notifier();

--- a/src/options.js
+++ b/src/options.js
@@ -143,4 +143,7 @@ function showHideReceiptsWarning (tabs){
   // page. We should get a onDisconnect event in the background page when
   // the popup goes away.
   chrome.runtime.connect({ name: 'popup' });
+  window.onblur = function () {
+    chrome.runtime.sendMessage({ message: 'clearBadge' });
+  };
 })();

--- a/src/toolbar_button.js
+++ b/src/toolbar_button.js
@@ -39,7 +39,7 @@ function updateToolbarButton(tab) {
         !/Chrome|Chromium/.test(navigator.userAgent)
       ) {
         // Detect Safari engine
-        chrome.browserAction.setBadgeText({ text: '!' });
+        chrome.browserAction.setBadgeText({ text: '1' });
       } else {
         chrome.browserAction.setBadgeText({ text: '🔔' });
         chrome.browserAction.setBadgeBackgroundColor({ color: '#404040' });

--- a/src/toolbar_button.js
+++ b/src/toolbar_button.js
@@ -34,7 +34,16 @@ function updateToolbarButton(tab) {
     ) {
       chrome.browserAction.setBadgeText({ text: '' });
     } else {
-      chrome.browserAction.setBadgeText({ text: '🔔' });
+      if (
+        /Safari/.test(navigator.userAgent) &&
+        !/Chrome|Chromium/.test(navigator.userAgent)
+      ) {
+        // Detect Safari engine
+        chrome.browserAction.setBadgeText({ text: '!' });
+      } else {
+        chrome.browserAction.setBadgeText({ text: '🔔' });
+        chrome.browserAction.setBadgeBackgroundColor({ color: '#404040' });
+      }
     }
 
     if (tab === null || tab === undefined) {


### PR DESCRIPTION
This PR addresses a few issues related to the badge introduced in #379, specifically for Safari. 

While running the QA steps, I found the following issues:

- Safari doesn't render emojis inside the badge like Firefox and Chrome.
- Badge background color customization is not supported. It's always red. This issue is documented in the MDN web docs, here's the link: [setBadgeBackgroundColor()-Mozilla | MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setBadgeBackgroundColor#browser_compatibility)
- The current approach to remove the badge after users close the popup window is not working in Safari. This issue is also reported here: https://github.com/lapcat/SafariExtensions/issues/40

This PR introduces the following changes:

- Adds logic to identify the Safari engine and uses an exclamation mark as a substitute for the bell emoji. Here's a screenshot of how it looks: 

![image](https://github.com/user-attachments/assets/2beeed78-eaad-4f42-a03e-bc0bb1516c11)

- Implements a new event-based approach to remove the badge after the popup closes. This method sends a message to the background script upon popup closure, bypassing the port-based mechanism used for Chrome and Firefox. Here's a GIF showing the badge is properly removed in Safari

![Screen Recording 2024-07-12 at 11 49 18 PM](https://github.com/user-attachments/assets/9bffc98a-6b02-4c3f-ba7e-b3450bcc1156)
