### PR TITLE
feat(pacer): Enhance isLoginPage to accurately identify login pages

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,7 +18,7 @@ Changes:
  - Adds a badge to the extension icon and a banner in the options menu([#379](https://github.com/freelawproject/recap-chrome/pull/379), [#380](https://github.com/freelawproject/recap-chrome/pull/380))
 
 Fixes:
- - None yet
+ - Enhance isLoginPage to accurately identify login pages([#373](https://github.com/freelawproject/recap/issues/373), [#381](https://github.com/freelawproject/recap-chrome/pull/381)).
  
 For developers:
  - Nothing yet

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -71,8 +71,12 @@ let PACER = {
   },
 
   // Returns true if the URL is for the login page
-  isLoginPage: function(url) {
-    return this.getCourtFromUrl(url) === 'login';
+  isLoginPage: function (url) {
+    isPacerLogin = this.getCourtFromUrl(url) === 'login' && url.includes('csologin/login.jsf');
+    // matches the URL for the login page to the Manage My Account interface in PACER. The url is:
+    // https://pacer.psc.uscourts.gov/pscof/login.xhtml
+    isManageAccountLogin = this.getCourtFromUrl(url) === 'psc' && url.includes('pscof/login.xhtml');
+    return isPacerLogin || isManageAccountLogin;
   },
 
   convertToCourtListenerCourt: function(pacer_court_id) {


### PR DESCRIPTION
While debugging https://github.com/freelawproject/recap/issues/373, I noticed pacer has 2 different login pages. One for the manage account page and another one to access pacer. Here are the URLs:

- https://pacer.login.uscourts.gov/csologin/login.jsf
![image](https://github.com/user-attachments/assets/1eb4a699-1c3a-471d-8e06-bd719e477d1b)


- https://pacer.psc.uscourts.gov/pscof/login.xhtml

![image](https://github.com/user-attachments/assets/a38e7702-4c58-47bd-a683-2ecb789244c7)


This PR refines the `isLoginPage` helper function to correctly detect both the standard and manage account login pages. It achieves this by employing a more specific approach checking the path.

After merging this PR, the extension will insert the banner in both login pages:

![image](https://github.com/user-attachments/assets/267e7a71-c070-4992-a01c-37355def716d)

![image](https://github.com/user-attachments/assets/06c3ea5d-c152-47c8-9d6a-b714a6283d9a)

Also, this PR fixes https://github.com/freelawproject/recap/issues/373

![image](https://github.com/user-attachments/assets/6673c50c-4e65-4c34-b587-8b92137a3713)

