### PR TITLE
feat(toolbar): Removes the warning icon for ACMS website

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,7 @@ Features:
 Changes:
  - Updates style and replace old logos with new ones([#378](https://github.com/freelawproject/recap-chrome/pull/378))
  - Adds a badge to the extension icon and a banner in the options menu([#379](https://github.com/freelawproject/recap-chrome/pull/379), [#380](https://github.com/freelawproject/recap-chrome/pull/380))
+ - Removes the warning icon on ACMS websites([#382](https://github.com/freelawproject/recap-chrome/pull/382))
 
 Fixes:
  - Enhance isLoginPage to accurately identify login pages([#373](https://github.com/freelawproject/recap/issues/373), [#381](https://github.com/freelawproject/recap-chrome/pull/381)).

--- a/src/toolbar_button.js
+++ b/src/toolbar_button.js
@@ -77,12 +77,6 @@ function updateToolbarButton(tab) {
           '19': 'assets/images/grey-19.png',
           '38': 'assets/images/grey-38.png'
         });
-      } else if (PACER.isACMSWebsite(tab.url)) {
-        // ACMS website. Show warning.
-        setTitleIcon('ACMS is not supported', {
-          '19': 'assets/images/warning-19.png',
-          '38': 'assets/images/warning-38.png'
-        });
       } else {
         // It's a valid PACER URL. Therefore either show the nice blue icon or
         // show the blue icon with a warning, if receipts are disabled.


### PR DESCRIPTION
This PR removes the logic that identified ACMS websites and displayed a warning icon indicating they are not supported. 