### PR TITLE
fix(appellate): Adds logic to check for 'selectedDocuments' key

### DIFF
--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -526,9 +526,15 @@ AppellateDelegate.prototype.handleAcmsDownloadPage = async function () {
           .toLowerCase()
           .includes('accept charges and retrieve');
 
-        let hasOneDocument = JSON.parse(
-          sessionStorage.selectedDocuments
-        ).length == 1;
+        // The `selectedDocuments` key in sessionStorage is only available when
+        // the download page is loaded from an attachment page. It is not
+        // available when loaded from a case summary entry. This check ensures
+        // the extension can handle both scenarios gracefully.
+        let hasOneDocument = true;
+        if (sessionStorage.getItem('selectedDocuments')) {
+          hasOneDocument =
+            JSON.parse(sessionStorage.selectedDocuments).length == 1;
+        }
 
         if (
           n.localName === 'div' &&


### PR DESCRIPTION
This PR fixes the MutationObserver function responsible for identifying ACMS download pages

In https://github.com/freelawproject/recap-chrome/pull/376, We introduced logic to check the number of documents on the download page and display a warning for combined PDFs. This code relied on data stored in `sessionStorage`. However, the key used to access this data is only set when the receipt page is loaded from an attachment page.

This PR addresses this limitation by implementing an additional check. This code makes sure the `MutationObserver` function continues to work correctly for receipt pages accessed from the docket summary.