### PR TITLE
fix(manifest): Refines content_scripts permissions on azure websites

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
  - None yet
  
 Fixes:
- - None yet
+ - Refines content_scripts permissions on azure websites([#374](https://github.com/freelawproject/recap/issues/374), [#385](https://github.com/freelawproject/recap-chrome/pull/385))
 
 For developers:
  - Nothing yet

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -92,21 +92,93 @@
       "background.js"
     ]
   },
-  "content_scripts": [{
-    "matches": ["*://*.uscourts.gov/*", "*://*.azurewebsites.us/*"],
-    "include_globs": ["*://ecf.*", "*://ecf-train.*", "*://pacer.*", "*://*-showdoc.*"],
-    "css": [
-      "assets/css/style.css",
-      "assets/css/font-awesome.css"
-    ],
-    "run_at": "document_end"
-  }, {
-    "matches": ["https://www.courtlistener.com/*"],
-    "js": [
-      "install_notifier.js"
-    ],
-    "run_at": "document_idle"
-  }],
+  "content_scripts": [
+    {
+      "matches": [
+        "*://*.uscourts.gov/*"
+      ],
+      "include_globs": [
+        "*://ecf.*",
+        "*://ecf-train.*",
+        "*://pacer.*"
+      ],
+      "css": [
+        "assets/css/style.css",
+        "assets/css/font-awesome.css"
+      ],
+      "run_at": "document_end"
+    },
+    {
+      "matches": [
+        "*://ca1-showdoc.azurewebsites.us/*",
+        "*://ca2-showdoc.azurewebsites.us/*",
+        "*://ca3-showdoc.azurewebsites.us/*",
+        "*://ca4-showdoc.azurewebsites.us/*",
+        "*://ca5-showdoc.azurewebsites.us/*",
+        "*://ca6-showdoc.azurewebsites.us/*",
+        "*://ca7-showdoc.azurewebsites.us/*",
+        "*://ca8-showdoc.azurewebsites.us/*",
+        "*://ca9-showdoc.azurewebsites.us/*",
+        "*://ca10-showdoc.azurewebsites.us/*",
+        "*://ca11-showdoc.azurewebsites.us/*",
+        "*://cafc-showdoc.azurewebsites.us/*",
+        "*://cadc-showdoc.azurewebsites.us/*",
+        "*://ca1-showdocservices.azurewebsites.us/*",
+        "*://ca2-showdocservices.azurewebsites.us/*",
+        "*://ca3-showdocservices.azurewebsites.us/*",
+        "*://ca4-showdocservices.azurewebsites.us/*",
+        "*://ca5-showdocservices.azurewebsites.us/*",
+        "*://ca6-showdocservices.azurewebsites.us/*",
+        "*://ca7-showdocservices.azurewebsites.us/*",
+        "*://ca8-showdocservices.azurewebsites.us/*",
+        "*://ca9-showdocservices.azurewebsites.us/*",
+        "*://ca10-showdocservices.azurewebsites.us/*",
+        "*://ca11-showdocservices.azurewebsites.us/*",
+        "*://cafc-showdocservices.azurewebsites.us/*",
+        "*://cadc-showdocservices.azurewebsites.us/*",
+        "*://ca1-portal.powerappsportals.us/*",
+        "*://ca2-portal.powerappsportals.us/*",
+        "*://ca3-portal.powerappsportals.us/*",
+        "*://ca4-portal.powerappsportals.us/*",
+        "*://ca5-portal.powerappsportals.us/*",
+        "*://ca6-portal.powerappsportals.us/*",
+        "*://ca7-portal.powerappsportals.us/*",
+        "*://ca8-portal.powerappsportals.us/*",
+        "*://ca9-portal.powerappsportals.us/*",
+        "*://ca10-portal.powerappsportals.us/*",
+        "*://ca11-portal.powerappsportals.us/*",
+        "*://cafc-portal.powerappsportals.us/*",
+        "*://cadc-portal.powerappsportals.us/*",
+        "*://ca1.fedcourts.us/*",
+        "*://ca2.fedcourts.us/*",
+        "*://ca3.fedcourts.us/*",
+        "*://ca4.fedcourts.us/*",
+        "*://ca5.fedcourts.us/*",
+        "*://ca6.fedcourts.us/*",
+        "*://ca7.fedcourts.us/*",
+        "*://ca8.fedcourts.us/*",
+        "*://ca9.fedcourts.us/*",
+        "*://ca10.fedcourts.us/*",
+        "*://ca11.fedcourts.us/*",
+        "*://cafc.fedcourts.us/*",
+        "*://cadc.fedcourts.us/*"
+      ],
+      "css": [
+        "assets/css/style.css",
+        "assets/css/font-awesome.css"
+      ],
+      "run_at": "document_end"
+    },
+    {
+      "matches": [
+        "https://www.courtlistener.com/*"
+      ],
+      "js": [
+        "install_notifier.js"
+      ],
+      "run_at": "document_idle"
+    }
+  ],
   "browser_action": {
     "default_icon": {
       "19": "assets/images/grey-19.png",


### PR DESCRIPTION
This PR updates the manifest file to implement a least privilege approach for permissions on Azure Websites. We're replacing the use of `include_globs` with a more granular approach that explicitly defines every single identified URL combination.

This change addresses concerns about overly broad permissions previously granted by the `matches` property. 

Fixes https://github.com/freelawproject/recap/issues/374

Here are screenshots showcasing the revised permission list. Notably, the option granting access to all Azure Websites sites is no longer included.

![image](https://github.com/user-attachments/assets/af6ee17c-d63c-4cfa-a3d2-f4d5b12d9148)

![image](https://github.com/user-attachments/assets/aaaf7140-d828-4baa-b880-fd3362178987)

