### PR TITLE
feat(manifest): Rename `applications` key to `browser_specific_settings`

### DIFF
--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -19,11 +19,11 @@ cd src/ && mv manifest.json manifest.base.json
 if [[ "$browserType" == "firefox" ]]; then
     faviconUrl='assets/images/favicon.icon'
     # Remove unnecessary properties for Firefox manifest
-    jq 'del(.background.service_worker, .background.type)' manifest.base.json >manifest.json
+    jq 'del(.background.service_worker)' manifest.base.json >manifest.json
 else
     faviconUrl='https://www.courtlistener.com/static/ico/favicon.ico'
     # Remove unnecessary property for Chrome/Chromium manifest
-    jq 'del(.background.scripts, .applications)' manifest.base.json >manifest.json
+    jq 'del(.background.scripts, .browser_specific_settings)' manifest.base.json >manifest.json
 fi
 
 # 4. Add search provider configuration to manifest

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -13,7 +13,7 @@
     "48": "assets/images/icon-48.png",
     "128": "assets/images/icon-128.png"
   },
-  "applications": {
+  "browser_specific_settings": {
     "gecko": {
       "id": "info@recapthelaw.org",
       "strict_min_version": "58.0"


### PR DESCRIPTION
This PR addresses the recent comment on issue [#333](https://github.com/freelawproject/recap/issues/333) regarding the warning encountered in Firefox. I noticed this warning message is still appearing when loading `.zip` files generated by the `build` script.

Following the [Firefox-specific migration checklist](https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/), this PR renames the deprecated `applications` key in `manifest.json` to the new `browser_specific_settings` key.

This PR also updates the `build` script to remove the `browser_specific_settings` key from chrome release packages.

This change has been tested locally and the warning no longer appears during Firefox builds.

![image](https://github.com/user-attachments/assets/77734882-7234-4c3c-ba52-f7bb2d860c48)
