### PR TITLE
fix(safari): Resolve manifest upgrade compatibility issues

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,10 @@ Changes:
  - None yet
  
 Fixes:
- - None yet
+ - Disables notifications in Safari due to API limitations ([391](https://github.com/freelawproject/recap-chrome/pull/391)).
 
 For developers:
- - Nothing yet
+ - Preserves permissions during macOS and iOS release package creation ([391](https://github.com/freelawproject/recap-chrome/pull/391))
 
 ## 2.8.0 (2024-08-27)
 

--- a/safari/build-safari.py
+++ b/safari/build-safari.py
@@ -44,14 +44,6 @@ def update_manifest_files(operating_system: str) -> None:
         f"cd {operating_system}/Recap && xcrun agvtool new-marketing-version {manifest['version']}"
     )
 
-    manifest["permissions"] = [
-        "*://*.uscourts.gov/",
-        "notifications",
-        "storage",
-        "unlimitedStorage",
-        "activeTab",
-        "cookies",
-    ]
     # The main difference between iOS and macOS is the permissions.
     if operating_system == "iOS":
         manifest["background"]["persistent"] = False

--- a/src/utils/background_notifier.js
+++ b/src/utils/background_notifier.js
@@ -29,6 +29,12 @@ const showNotification = function (title, message, cb) {
   console.info(
     'RECAP: Running showNotification function. Expect a notification.'
   );
+  // Avoid triggering notifications for Safari because the API is not supported
+  if (
+    /Safari/.test(navigator.userAgent) &&
+    !/Chrome|Chromium/.test(navigator.userAgent)
+  )
+    return;
   chrome.notifications.create(id, notificationOptions(title, message));
   // Make it go away when clicked.
   chrome.notifications.onClicked.addListener((id) =>


### PR DESCRIPTION
This PR addresses the following issues: 

- **Updates the script that creates the MacOS and iOS version of the extension**: After updating the manifest file to include new API permissions, the `update_manifest_files` helper method was overwriting the existing permissions for the macOS and iOS versions of the extension with a hardcoded list(This caused compatibility issues). The PR removes the hardcoded permissions list from the helper method, ensuring that the same set of permissions is used across all browsers.
 
- While testing the extension, I noticed that the code that creates notifications was consistently raising exceptions.  Investigating the [Notifications API documentation ](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/notifications/create), I realized **Safari** currently doesn't support this functionality. To prevent these errors and ensure a smooth user experience across browsers, I implemented an early return mechanism within the `showNotification` function. This return now occurs specifically when the extension detects it's running in **Safari**.