### PR TITLE
feat(toolbar): Enhance banners with updated content

### DIFF
--- a/src/content.js
+++ b/src/content.js
@@ -47,31 +47,6 @@ async function addRecapInformation(msg) {
       });
     }
 
-    const options = await getItemsFromStorage('options');
-    if (
-      'login_dismiss_new_brand_info' in options &&
-      options['login_dismiss_new_brand_info']
-    ) {
-      return;
-    }
-
-    let bannerMessage =
-      'Get ready for a new chapter! RECAP is getting a ' + 'fresh new look.';
-    let bannerLink = 'https://free.law/2024/07/05/new-branding-rip-flip';
-    PACER.addRecapBannerToLoginPage(bannerMessage, bannerLink);
-
-    let dismiss_button = document.getElementById('dismiss_recap_info_banner');
-    dismiss_button.addEventListener('click', async () => {
-      await PACER.removeBannerFromLoginPage();
-      return false;
-    });
-
-    let learn_more_btn = document.getElementById('learn_more_btn');
-    learn_more_btn.addEventListener('click', async () => {
-      await PACER.removeBannerFromLoginPage(event_from_btn = true);
-      return true;
-    });
-
     return;
   }
 

--- a/src/options.html
+++ b/src/options.html
@@ -25,8 +25,7 @@
               </div>
             </div>
             <p id="info-banner-message">
-              <b>Get ready for a new chapter!</b> RECAP is getting a fresh new look.
-            </p>
+              <b>RECAP is using Manifest Version 3 now</b>. Enjoy improved features and performance.
             <div id="dismiss-banner" class="d-flex align-items-start justify-content-end">
               <button type="button" class="close" aria-label="Close">
                 <span aria-hidden="true">&times;</span>
@@ -35,7 +34,7 @@
           </div>
           <div class="input-group-append d-flex justify-content-center">
             <a class="btn btn-primary" id="learn-more-button" target="_blank" rel="noopener"
-              href="https://free.law/2024/07/05/new-branding-rip-flip">
+              href="https://github.com/freelawproject/recap-chrome/releases/tag/2.8.0">
               &nbsp;Learn More
             </a>
           </div>

--- a/src/options.js
+++ b/src/options.js
@@ -21,7 +21,7 @@ async function load_options() {
         inputs[i].value = items.options[inputs[i].id] || '';
       }
     }
-    if ('option_dismiss_new_brand_info' in items.options) removeInfoBanner();
+    if ('option_dismiss_new_manifest_info' in items.options) removeInfoBanner();
   });
 }
 
@@ -38,7 +38,7 @@ function save_options() {
 
     let banner = document.getElementById('header-banner');
     if (!banner) {
-      options['option_dismiss_new_brand_info'] = true;
+      options['option_dismiss_new_manifest_info'] = true;
     }
 
     chrome.storage.local.set({ options: options }, function () {

--- a/src/utils/toolbar_button.js
+++ b/src/utils/toolbar_button.js
@@ -37,16 +37,9 @@ export function updateToolbarButton(tab) {
     ) {
       chrome.action.setBadgeText({ text: '' });
     } else {
-      if (
-        /Safari/.test(navigator.userAgent) &&
-        !/Chrome|Chromium/.test(navigator.userAgent)
-      ) {
-        // Detect Safari engine
-        chrome.action.setBadgeText({ text: '1' });
-      } else {
-        chrome.action.setBadgeText({ text: '🔔' });
-        chrome.action.setBadgeBackgroundColor({ color: '#404040' });
-      }
+      chrome.action.setBadgeText({ text: '1' });
+      chrome.action.setBadgeTextColor({ color: 'white' });
+      chrome.action.setBadgeBackgroundColor({ color: 'red' });
     }
 
     if (tab === null || tab === undefined) {


### PR DESCRIPTION
This PR removes the banner from the login page and updates the banner within the options page to inform users about the code upgrade to Manifest Version 3. Additionally, it updates the badge icon style to use a number instead of the bell emoji for Firefox and Chrome.

Here are screenshots showing the banner and the badge icon:

![image](https://github.com/user-attachments/assets/df100b21-3e35-4f41-b401-d423f02b59d9)

-----

![image](https://github.com/user-attachments/assets/7113db0d-9fb6-497a-b9a7-03f05f821516)

----

![Screen Recording 2024-09-11 at 5 07 20 PM](https://github.com/user-attachments/assets/65ee6d65-b3da-4a1c-8bb3-eccb5a073f5b)

