### PR TITLE
feat(background): Adds logic to clean up storage after upload

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@ Changes:
 Fixes:
  - Disables notifications in Safari due to API limitations ([391](https://github.com/freelawproject/recap-chrome/pull/391)).
  - Fix fetch on firefox ([393](https://github.com/freelawproject/recap-chrome/pull/393)).
+ - Adds logic to clean up storage after uploads ([395](https://github.com/freelawproject/recap-chrome/pull/395)).
 
 For developers:
  - Preserves permissions during macOS and iOS release package creation ([391](https://github.com/freelawproject/recap-chrome/pull/391))

--- a/src/utils/background_fetch.js
+++ b/src/utils/background_fetch.js
@@ -100,6 +100,13 @@ async function triggerFetchRequest(url, options, sender, sendResponse) {
     const blob = await fetch(file).then((res) => res.blob());
     const body = buildFormData({ ...options.body, filepath_local: blob });
     await waitUntil(dispatchCallback(url, { ...options, body }));
+
+    // Remove the 'pdf_blob' and 'zip_blob' properties from the specified key
+    // in Chrome's local storage after uploading their content.
+    if (store[storeKey]['pdf_blob']) delete store[storeKey]['pdf_blob'];
+    if (store[storeKey]['zip_blob']) delete store[storeKey]['zip_blob'];
+    await chrome.storage.local.set({ [storeKey]: store[storeKey] });
+    console.info('Temporary file data removed from storage.');
   });
   // return true to allow for the async function to complete
   return true;


### PR DESCRIPTION
During QA testing for the upcoming extension release, I noticed that temporary upload data (files and zips) was not being removed from local storage after successful uploads. This issue could potentially lead to unnecessary storage usage and performance concerns.

This PR addresses the problem by tweaking the `triggerFetchRequest` method in `background_fetch.js`. The changes ensure that temporary data is consistently deleted from local storage once the upload process is complete.