### PR TITLE
fix(scripts): Corrected typo in build script

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
  - None yet
  
 Fixes:
- - None yet
+ - Corrected typo in build script, ensuring correct favicon path for Firefox releases([379](https://github.com/freelawproject/recap/issues/379), [397](https://github.com/freelawproject/recap-chrome/pull/397))
 
 For developers:
  - Nothing yet

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -17,7 +17,7 @@ zipName=$browserType-release.zip
 # 3. Rename base manifest file
 cd src/ && mv manifest.json manifest.base.json
 if [[ "$browserType" == "firefox" ]]; then
-    faviconUrl='assets/images/favicon.icon'
+    faviconUrl='assets/images/favicon.ico'
     # Remove unnecessary properties for Firefox manifest
     jq 'del(.background.service_worker)' manifest.base.json >manifest.json
 else


### PR DESCRIPTION
This commit fixes a typo in the path of the favicon file within release build script. The incorrect path was preventing the favicon from being rendered in the browser. By correcting the typo, the favicon will now be displayed as expected.

![image](https://github.com/user-attachments/assets/b9273d64-5124-4669-b957-67f7ecb265df)

Fixes https://github.com/freelawproject/recap/issues/379