### PR TITLE
fix(district): Attaches pacer_case_id to entry links

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
  
 Fixes:
  - Corrected typo in build script, ensuring correct favicon path for Firefox releases([379](https://github.com/freelawproject/recap/issues/379), [397](https://github.com/freelawproject/recap-chrome/pull/397))
+ - Attaches the pacer_case_id as a query parameter to entry links in District Courts Reports ([369](https://github.com/freelawproject/recap/issues/369), [398](https://github.com/freelawproject/recap-chrome/pull/398)).
 
 For developers:
  - Nothing yet

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -436,7 +436,7 @@ describe('The PACER module', function () {
   });
 
   describe('getDocumentIdFronForm', function () {
-    const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','');";
+    const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','','','');";
     let form;
     beforeEach(function () {
       form = document.createElement('form');
@@ -477,7 +477,7 @@ describe('The PACER module', function () {
   });
 
   describe('getCaseNumberFromInputs', function () {
-    const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','');";
+    const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','','');";
     const input = document.createElement('input');
 
     beforeEach(function () {
@@ -516,7 +516,7 @@ describe('The PACER module', function () {
 
   describe('parseGoDLSFunction', function () {
     it('gets the right values for an example DLS string', function () {
-      let goDLSSampleString = "goDLS('/doc1/09518360046','153992','264','','','1','',''); " + 'return(false);';
+      let goDLSSampleString = "goDLS('/doc1/09518360046','153992','264','','','1','','',''); " + 'return(false);';
       expect(PACER.parseGoDLSFunction(goDLSSampleString)).toEqual({
         hyperlink: '/doc1/09518360046',
         de_caseid: '153992',
@@ -526,6 +526,7 @@ describe('The PACER module', function () {
         pdf_toggle_possible: '1',
         magic_num: '',
         hdr: '',
+        psf_report: '',
       });
     });
 

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -605,17 +605,33 @@ ContentDelegate.prototype.attachRecapLinkToEligibleDocs = async function () {
     if (!result) continue;
 
     let href = `https://storage.courtlistener.com/${result.filepath_local}`;
-    let recap_link = $('<a/>', {
+    let recapLink = $('<a/>', {
       class: 'recap-inline',
       title: 'Available for free from the RECAP Archive.',
       href: href,
     });
-    recap_link.append(
+    recapLink.append(
       $('<img/>').attr({
         src: chrome.runtime.getURL('assets/images/icon-16.png'),
       })
     );
-    recap_link.insertAfter(this.links[i]);
+    recapLink.insertAfter(this.links[i]);
+
+    // Attaches the case ID to the entry link as a query parameter. This allows
+    // us to access it from the URL, even if it's not available in the
+    // subsequent page's DOM.
+    entryLink = this.links[i];
+    let url = new URL(entryLink.href);
+    url.searchParams.set('caseId', this.pacer_case_id);
+    entryLink.setAttribute('href', url.toString());
+
+    entryLink.removeAttribute('onclick');
+    entryLink.setAttribute('target', '_self');
+    entryLink.dataset.recap =
+      'Modified by RECAP Extension to add caseId' + 'attribute.';
+    // clone and replace anchor elements to remove all listeners
+    let clonedNode = entryLink.cloneNode(true);
+    entryLink.replaceWith(clonedNode);
   }
   let spinner = document.getElementById('recap-button-spinner');
   if (spinner) {

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -536,9 +536,9 @@ let PACER = {
     //   https://ecf.flnd.uscourts.gov/lib/dls_url.js
     // as:
     //   function goDLS(hyperlink, de_caseid, de_seqno, got_receipt,
-    //                  pdf_header, pdf_toggle_possible, magic_num, hdr)
+    //                  pdf_header, pdf_toggle_possible, magic_num, hdr, psf_report)
     //
-    // Bankruptcy courts provide ten parameters, instead of eight. These can
+    // Bankruptcy courts provide ten parameters, instead of nine. These can
     // be found in unminified js:
     //   https://ecf.paeb.uscourts.gov/lib/dls_url.js
     // as:
@@ -548,7 +548,7 @@ let PACER = {
     // Δ:
     // - hdr
     // + claim_id, claim_num, claim_doc_seq
-    let goDlsDistrict = /^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/.exec(goDLS_string);
+    let goDlsDistrict = /^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/.exec(goDLS_string);
     let goDlsBankr= /^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/.exec(goDLS_string);
     if (!goDlsDistrict && !goDlsBankr) {
       return null;
@@ -556,7 +556,7 @@ let PACER = {
     let r = {};
     if (goDlsDistrict){
       [, r.hyperlink, r.de_caseid, r.de_seqno, r.got_receipt, r.pdf_header,
-        r.pdf_toggle_possible, r.magic_num, r.hdr] = goDlsDistrict;
+        r.pdf_toggle_possible, r.magic_num, r.hdr, r.psf_report] = goDlsDistrict;
     } else {
       [, r.hyperlink, r.de_caseid, r.de_seqno, r.got_receipt, r.pdf_header,
         r.pdf_toggle_possible, r.magic_num, r.claim_id, r.claim_num,


### PR DESCRIPTION
This PR introduces logic to attach the `pacer_case_id` as a query parameter to entry links. This updates ensures the case ID is  easily accessible from the URL even if it's not present in the subsequent page's DOM. This will simplify the process of navigating between pages while retaining important case information.

This PR partially fixes https://github.com/freelawproject/recap/issues/369. Users accessing attachment pages from CourtListener or the docket report will no longer encounter problems. However, the extension's ability to capture attachment pages remains limited when users employ links from sources outside these two.

@mlissner If the extension is unable to gather all the necessary data for a page upload, should we display a warning message to alert users of the potential issue and guide them towards a successful upload?