### PR TITLE
fix(district): Refine generateFileName method for large documents

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
  
 Fixes:
  - Corrected typo in build script, ensuring correct favicon path for Firefox releases([379](https://github.com/freelawproject/recap/issues/379), [397](https://github.com/freelawproject/recap-chrome/pull/397))
+ - Refines the generateFileName method to accurately compute zip file names ([366](https://github.com/freelawproject/recap/issues/366), [399](https://github.com/freelawproject/recap-chrome/pull/399)).
 
 For developers:
  - Nothing yet

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -662,9 +662,34 @@ ContentDelegate.prototype.onDownloadAllSubmit = async function (event) {
         .concat('.zip');
     } else if (options.lawyer_style_filenames) {
       const firstTable = document.getElementsByTagName('table')[0];
+      // The download page's tables typically display transaction details.
+      // However, only certain rows contain relevant information:
+      //
+      // 1. Table Title.
+      // 2. Subtitle.
+      // 3. Date of Transaction
+      // 4. Pacer Login Data: Includes the Pacer login username and client code.
+      // 5. Description and Case Number.
+      // 6. Billable Pages and Cost.
+      //
+      // Additionally, if the document has more than 30 pages, an extra row is
+      // added to inform the user that they will only be billed for 30 pages.
       const firstTableRows = firstTable.querySelectorAll('tr');
-      // 4th from bottom
-      const matchedRow = firstTableRows[firstTableRows.length - 4];
+      // Remove rows from the querySelectorAll result that have no visible
+      // content.
+      const rowsWithContent = Array.from(firstTableRows).filter((row) =>
+        row.hasChildNodes()
+      );
+      const lastRow = rowsWithContent[rowsWithContent.length -1];
+      let matchedRow;
+      // Find the row containing the Description and Case Number. If the last
+      // row contains the billing message for documents exceeding 30 pages,
+      // adjusts the index accordingly.
+      if (lastRow.innerHTML.includes('You will only be billed for 30 pages')){
+        matchedRow = rowsWithContent[rowsWithContent.length - 3];
+      } else {
+        matchedRow = rowsWithContent[rowsWithContent.length - 2];
+      }
       const cells = matchedRow.querySelectorAll('td');
       const document_number = cells[0].innerText.match(/\d+(?=\-)/)[0];
       const docket_number = cells[1].innerText;


### PR DESCRIPTION
This PR fixes https://github.com/freelawproject/recap/issues/366 by refining the `generateFileName` method to accurately compute zip file names, even for cases where the first document exceeds 30 pages. Previously, the logic lead to an error in such cases. This update addresses the issue by employing a more robust approach to compute the file name.

Here are some GIFs demonstrating the download functionality:

- Downloading Large Zip Files (Over 30 Pages):

![Screen Recording 2024-09-18 at 8 29 51 PM](https://github.com/user-attachments/assets/eb9d64ce-8cfc-4055-83a6-2a24c161ac71)


- Downloading Smaller Documents (Under 30 Pages):

![Screen Recording 2024-09-18 at 8 31 10 PM](https://github.com/user-attachments/assets/c2494549-fb8d-4fb8-97e4-798bcb56748b)
