### PR TITLE
feat(district): Capture attachment pages with no footer form

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,6 +12,7 @@ Changes:
  
 Fixes:
  - Corrected typo in build script, ensuring correct favicon path for Firefox releases([379](https://github.com/freelawproject/recap/issues/379), [397](https://github.com/freelawproject/recap-chrome/pull/397))
+ - Improves the reliability of PACER case ID retrieval on attachment pages ([369](https://github.com/freelawproject/recap/issues/369), [400](https://github.com/freelawproject/recap-chrome/pull/400)).
 
 For developers:
  - Nothing yet

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -436,7 +436,7 @@ describe('The PACER module', function () {
   });
 
   describe('getDocumentIdFronForm', function () {
-    const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','');";
+    const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','','','');";
     let form;
     beforeEach(function () {
       form = document.createElement('form');
@@ -477,7 +477,7 @@ describe('The PACER module', function () {
   });
 
   describe('getCaseNumberFromInputs', function () {
-    const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','');";
+    const goDLS = "goDLS('/doc1/09518360046','153992','264','','','1','','','');";
     const input = document.createElement('input');
 
     beforeEach(function () {
@@ -516,7 +516,7 @@ describe('The PACER module', function () {
 
   describe('parseGoDLSFunction', function () {
     it('gets the right values for an example DLS string', function () {
-      let goDLSSampleString = "goDLS('/doc1/09518360046','153992','264','','','1','',''); " + 'return(false);';
+      let goDLSSampleString = "goDLS('/doc1/09518360046','153992','264','','','1','','',''); " + 'return(false);';
       expect(PACER.parseGoDLSFunction(goDLSSampleString)).toEqual({
         hyperlink: '/doc1/09518360046',
         de_caseid: '153992',
@@ -526,6 +526,7 @@ describe('The PACER module', function () {
         pdf_toggle_possible: '1',
         magic_num: '',
         hdr: '',
+        psf_report: '',
       });
     });
 

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -367,6 +367,15 @@ ContentDelegate.prototype.handleAttachmentMenuPage = async function () {
     return;
   }
 
+  if (!this.pacer_case_id)
+    this.pacer_case_id = await getPacerCaseIdFromPacerDocId(
+      this.tabId,
+      this.pacer_doc_id
+    );
+
+  // If we don't have this.pacer_case_id at this point, punt.
+  if (!this.pacer_case_id) return;
+
   const upload = await dispatchBackgroundFetch({
     action: 'upload',
     data: {

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -536,9 +536,9 @@ let PACER = {
     //   https://ecf.flnd.uscourts.gov/lib/dls_url.js
     // as:
     //   function goDLS(hyperlink, de_caseid, de_seqno, got_receipt,
-    //                  pdf_header, pdf_toggle_possible, magic_num, hdr)
+    //                  pdf_header, pdf_toggle_possible, magic_num, hdr, psf_report)
     //
-    // Bankruptcy courts provide ten parameters, instead of eight. These can
+    // Bankruptcy courts provide ten parameters, instead of nine. These can
     // be found in unminified js:
     //   https://ecf.paeb.uscourts.gov/lib/dls_url.js
     // as:
@@ -548,7 +548,7 @@ let PACER = {
     // Δ:
     // - hdr
     // + claim_id, claim_num, claim_doc_seq
-    let goDlsDistrict = /^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/.exec(goDLS_string);
+    let goDlsDistrict = /^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/.exec(goDLS_string);
     let goDlsBankr= /^goDLS\('([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)','([^']*)'\)/.exec(goDLS_string);
     if (!goDlsDistrict && !goDlsBankr) {
       return null;
@@ -556,7 +556,7 @@ let PACER = {
     let r = {};
     if (goDlsDistrict){
       [, r.hyperlink, r.de_caseid, r.de_seqno, r.got_receipt, r.pdf_header,
-        r.pdf_toggle_possible, r.magic_num, r.hdr] = goDlsDistrict;
+        r.pdf_toggle_possible, r.magic_num, r.hdr, r.psf_report] = goDlsDistrict;
     } else {
       [, r.hyperlink, r.de_caseid, r.de_seqno, r.got_receipt, r.pdf_header,
         r.pdf_toggle_possible, r.magic_num, r.claim_id, r.claim_num,


### PR DESCRIPTION
key changes: 

- Updates the `parseGoDLSFunction` helper to accommodate new parameters present in district links.

- Adresses https://github.com/freelawproject/recap/issues/369 where PACER case IDs weren't reliably extracted on attachment pages by implementing suggestions outlined in https://github.com/freelawproject/recap-chrome/pull/398#issuecomment-2359524279 to enhance retrieval logic. 