### PR TITLE
feat(pacer): Refine multi-document page handling logic

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 The following changes are not yet released, but are code complete:
 
 Features:
- - None yet
+ - Refines logic to accurately identify multi-document pages containing a single file ([349](https://github.com/freelawproject/recap/issues/349), [402](https://github.com/freelawproject/recap-chrome/pull/402)) 
 
 Changes:
  - Upgrade to CourtListener v4 API([380](https://github.com/freelawproject/recap/issues/380), [401](https://github.com/freelawproject/recap-chrome/pull/401))

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -1239,8 +1239,15 @@ AppellateDelegate.prototype.onDocumentViewSubmit = async function (event) {
     return;
   }
 
-  if (!pdfData.att_number && this.queryParameters.get('recapAttNum')) {
-    pdfData.att_number = this.queryParameters.get('recapAttNum');
+  if (!pdfData.att_number) {
+    if (this.queryParameters.get('recapAttNum')) {
+      pdfData.att_number = this.queryParameters.get('recapAttNum');
+    } else {
+      pdfData.att_number = await getAttachmentNumberFromPacerDocId(
+        this.tabId,
+        this.docId
+      );
+    }
   }
 
   if (pdfData.doc_number.length > 9) {

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -1094,50 +1094,12 @@ AppellateDelegate.prototype.handleCombinedPdfPageView = async function () {
     false
   );
 
-  await this.checkSingleDocInCombinedPDFPage();
-};
-
-AppellateDelegate.prototype.checkSingleDocInCombinedPDFPage = async function(){
-  let clCourt = PACER.convertToCourtListenerCourt(this.court);
-  // Retrieves a partial document ID from the URL parameter named `"dls"`. It's
-  // important to note that this value might not be the complete document ID.
-  // It could potentially be a shortened version of the full ID.
-  let urlParams = new URLSearchParams(window.location.search);
-  let partialDocId = urlParams.get('dls').split(',')[0];
-
-  // If the `this.pacer_doc_id` property is not already set, attempt to retrieve
-  // it using the previously extracted partial document ID. The returned full
-  // document ID is then stored in the `this.pacer_doc_id` property for
-  // subsequent use.
-  if (!this.docId) {
-    this.docId = await getPacerDocIdFromPartialId(
-      this.tabId,
-      partialDocId
-    );
-  }
-
-  // If we don't have this.pacer_doc_id at this point, punt.
-  if (!this.docId) return;
-
-  const recapLinks = await dispatchBackgroundFetch({
-    action: 'getAvailabilityForDocuments',
-    data: {
-      docket_entry__docket__court: clCourt,
-      pacer_doc_id__in: this.docId,
-    },
-  });
-  if (!recapLinks.results.length) return;
-  console.info(
-    'RECAP: Got results from API. Processing results to insert link'
+  this.docId = await checkSingleDocInCombinedPDFPage(
+    this.tabId,
+    this.court,
+    this.docId,
+    true
   );
-
-  let result = recapLinks.results.filter(
-    (doc) => doc.pacer_doc_id === this.docId,
-    this
-  );
-  if (!result.length) return;
-
-  insertAvailableDocBanner(result[0].filepath_local, 'body');
 };
 
 // If this page offers a single document, intercept navigation to the document

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -846,12 +846,13 @@ AppellateDelegate.prototype.attachRecapLinksToEligibleDocs = async function () {
   }
 
   // filter the links for the documents available on the page
-  let { links, docsToCases } = APPELLATE.findDocLinksFromAnchors(
-    this.links,
-    this.tabId,
-    this.queryParameters,
-    this.docketNumber
-  );
+  let { links, docsToCases, docsToAttachmentNumbers } =
+    APPELLATE.findDocLinksFromAnchors(
+      this.links,
+      this.tabId,
+      this.queryParameters,
+      this.docketNumber
+    );
 
   this.pacer_case_id = this.pacer_case_id
     ? this.pacer_case_id
@@ -871,6 +872,7 @@ AppellateDelegate.prototype.attachRecapLinksToEligibleDocs = async function () {
       caseId: this.pacer_case_id,
       docketNumber: this.docketNumber,
       docsToCases: docsToCases,
+      docsToAttachmentNumbers: docsToAttachmentNumbers,
     },
   });
 

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -605,8 +605,15 @@ AppellateDelegate.prototype.handleAcmsDownloadPage = async function () {
           console.info(
             'RECAP: Got results from API. Processing results to insert banner'
           );
+          // To accurately identify ACMS documents, we should prioritize the
+          // `ACMS document details ID` stored in browser sessionStorage over
+          // the docket entry ID. This is because ACMS often uses the same URL
+          // for different attachments, making it ambiguous for identification
+          // purposes.
+          let acms_doc_id =
+            downloadData.docketEntryDocuments[0].docketDocumentDetailsId;
           let result = recapLinks.results.filter(
-            (obj) => obj.pacer_doc_id == this.docId,
+            (obj) => obj.acms_document_guid == acms_doc_id,
             this
           )[0];
           if (!result) return;
@@ -1117,6 +1124,7 @@ AppellateDelegate.prototype.checkSingleDocInCombinedPDFPage = async function(){
   console.info(
     'RECAP: Got results from API. Processing results to insert link'
   );
+
   let result = recapLinks.results.filter(
     (doc) => doc.pacer_doc_id === this.docId,
     this

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -238,17 +238,19 @@ let APPELLATE = {
     Array.from(nodeList).map((a) => {
       if (!PACER.isDoc1Url(a.href)) return;
 
-      let docNum = PACER.getDocNumberFromAnchor(a) || queryParameters.get('recapDocNum');
+      let docNum =
+        PACER.getDocNumberFromAnchor(a) || queryParameters.get('recapDocNum');
       let doDoc = PACER.parseDoDocPostURL(a.getAttribute('onclick'));
-      if (doDoc && doDoc.doc_id && doDoc.case_id) {
-        docsToCases[doDoc.doc_id] = doDoc.case_id;
+      let pacerCaseId =
+        (doDoc && doDoc.case_id) || queryParameters.get('caseId');
+      if (doDoc && doDoc.doc_id && pacerCaseId) {
+        docsToCases[doDoc.doc_id] = pacerCaseId;
       }
 
       a.removeAttribute('onclick');
       a.setAttribute('target', '_self');
 
       let url = new URL(a.href);
-      let pacerCaseId = (doDoc && doDoc.case_id) || queryParameters.get('caseId');
       url.searchParams.set('caseId', pacerCaseId);
 
       if (docNum) {

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -374,6 +374,24 @@ let APPELLATE = {
     return r;
   },
 
+  // returns data from the table of the Receipt Page as an object
+  parseDataFromReceiptTable: () => {
+    // this method uses regex expressions to match that information from the
+    // receipt table and returns an object with the following attributes:
+    //  - docket_number
+    //  - doc_number
+    //  - att_number (if applicable).
+    let search_string = $('td:contains(Case)').text();
+    let regex =
+      /Case: (?<docket_number>[^']*), Document: (?<doc_number>\d+)(-(?<att_number>\d+))?/;
+    let matches = regex.exec(search_string);
+    // If no matches were found, return null.
+    if (!matches) return null;
+    // If an attachment number was not found, set it to 0.
+    if (!matches.groups.att_number) matches.groups.att_number = 0;
+    return matches.groups;
+  },
+
   // Returns an object with the court Id and docket number core extracted from a link to district court
   getDatafromDistrictLinkUrl: (url) => {
     // Converts links to district courts like:

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -235,6 +235,7 @@ let APPELLATE = {
   findDocLinksFromAnchors: function (nodeList, tabId, queryParameters, docketNumber) {
     let links = [];
     let docsToCases = {};
+    let docsToAttachmentNumbers = {};
     Array.from(nodeList).map((a) => {
       if (!PACER.isDoc1Url(a.href)) return;
 
@@ -290,11 +291,14 @@ let APPELLATE = {
       clonedNode.dataset.pacerCaseId = pacerCaseId;
       clonedNode.dataset.pacerTabId = tabId;
       clonedNode.dataset.documentNumber = docNum ? docNum : docId;
-      if (attNumber) clonedNode.dataset.attachmentNumber = attNumber;
+      if (attNumber) {
+        clonedNode.dataset.attachmentNumber = attNumber;
+        docsToAttachmentNumbers[docId] = attNumber;
+      }
 
       links.push(docId);
     });
-    return { links, docsToCases };
+    return { links, docsToCases , docsToAttachmentNumbers};
   },
 
   // get the docId from the servlet parameter of the attachment page or the single doc page

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -859,10 +859,16 @@ ContentDelegate.prototype.handleZipFilePageView = function () {
 ContentDelegate.prototype.handleCombinedPDFView = function () {
   if (!PACER.isCombinedPdfPage(this.url, document)) return false;
 
-  // query the main div of the page
-  let mainDiv = document.getElementById((id = 'cmecfMainContent'));
-  pdfWarning = combinedPdfWarning();
-  mainDiv.append(pdfWarning);
+  // Find all center divs, which typically wrap receipt tables.
+  // Count the number of divs to determine how many documents are on the page.
+  // Display a warning if there's more than one document.
+  let transactionReceiptTables = document.querySelectorAll('center');
+  if (transactionReceiptTables.length > 1) {
+    let mainDiv = document.getElementById((id = 'cmecfMainContent'));
+    pdfWarning = combinedPdfWarning();
+    mainDiv.append(pdfWarning);
+    return;
+  }
 };
 
 ContentDelegate.prototype.handleClaimsPageView = async function () {

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -857,7 +857,7 @@ ContentDelegate.prototype.handleZipFilePageView = function () {
 
 // If the page offers a combined document, inserts a warning to let
 // the user know this document won't be uploaded.
-ContentDelegate.prototype.handleCombinedPDFView = function () {
+ContentDelegate.prototype.handleCombinedPDFView = async function () {
   if (!PACER.isCombinedPdfPage(this.url, document)) return false;
 
   // Find all center divs, which typically wrap receipt tables.
@@ -870,6 +870,51 @@ ContentDelegate.prototype.handleCombinedPDFView = function () {
     mainDiv.append(pdfWarning);
     return;
   }
+
+  await this.checkSingleDocInCombinedPDFPage();
+};
+
+
+// checks if a specific document within a combined PDF page is available in
+// the Recap archive. The document is identified by its PACER document ID.
+// If the document is found, it inserts a banner to inform the user of its
+// availability.
+ContentDelegate.prototype.checkSingleDocInCombinedPDFPage = async function (){
+  let clCourt = PACER.convertToCourtListenerCourt(this.court);
+  const urlParams = new URLSearchParams(window.location.search);
+  // The URL of multi-document pages often contains a list of documents that
+  // are excluded from purchase.
+  let excludeList = urlParams.get('exclude_attachments').split(',');
+  // If the `this.pacer_doc_id` property is not already set, attempt to retrieve
+  // it from the extracted `excludeList`.
+  if (!this.pacer_doc_id) {
+    this.pacer_doc_id = await getPacerDocIdFromExcludeList(
+      this.tabId,
+      excludeList
+    );
+  }
+
+  // If we don't have this.pacer_doc_id at this point, punt.
+  if (!this.pacer_doc_id) return;
+
+  const recapLinks = await dispatchBackgroundFetch({
+    action: 'getAvailabilityForDocuments',
+    data: {
+      docket_entry__docket__court: clCourt,
+      pacer_doc_id__in: this.pacer_doc_id,
+    },
+  });
+  if (!recapLinks.results.length) return;
+  console.info(
+    'RECAP: Got results from API. Processing results to insert link'
+  );
+  let result = recapLinks.results.filter(
+    (doc) => doc.pacer_doc_id === this.pacer_doc_id,
+    this
+  );
+  if (!result.length) return;
+
+  insertAvailableDocBanner(result[0].filepath_local, 'form:last');
 };
 
 ContentDelegate.prototype.handleClaimsPageView = async function () {

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -871,9 +871,97 @@ ContentDelegate.prototype.handleCombinedPDFView = async function () {
     return;
   }
 
+  // Extract the URL from the `onclick` attribute of one of the "Download
+  // Documents" buttons
+  const inputs = [...document.getElementsByTagName('input')];
+  const targetInputs = inputs.filter((input) => input.type === 'button');
+  const url = targetInputs[0]
+    .getAttribute('onclick')
+    .replace(/p.*\//, '') // remove parent.location='/cgi-bin/
+    .replace(/\'(?=$)/, ''); // remove endquote
+
+  // Manipulate the dom elements without injecting a script
+  if (PACER.hasFilingCookie(document.cookie)) {
+    const inputs = [
+      ...document.querySelectorAll("form > input[type='button']"),
+    ];
+    inputs.map((input) => {
+      let button = createRecapButtonForFilers('Download and RECAP Document');
+      let spinner = createRecapSpinner();
+      button.addEventListener('click', (event) => {
+        event.preventDefault();
+
+        let spinners = document.querySelectorAll('.recap-btn-spinner-hidden');
+        for (const spinner of spinners) {
+          // Access and process each process result element here
+          spinner.classList.remove('recap-btn-spinner-hidden');
+        }
+
+        window.postMessage({ id: url });
+      });
+      // insert new button next to the "Download Documents" button
+      input.after(spinner);
+      input.after(document.createTextNode('\u00A0'));
+      input.after(button);
+    });
+  } else {
+    const forms = [...document.querySelectorAll('form')];
+    forms.map((form) => {
+      form.removeAttribute('action');
+      const input = form.querySelector('input');
+      input.removeAttribute('onclick');
+      input.disabled = true;
+      form.hidden = true;
+      const div = document.createElement('div');
+      const button = document.createElement('button');
+      button.textContent = 'View Document';
+      button.addEventListener('click', () => window.postMessage({ id: url }));
+      div.appendChild(button);
+      const parentNode = form.parentNode;
+      parentNode.insertBefore(div, form);
+    });
+  }
+  // When we receive the message from the above submit method, submit the form
+  // via fetch so we can get the document before the browser does.
+  window.addEventListener('message', this.onDownloadSubmit.bind(this));
+
   await this.checkSingleDocInCombinedPDFPage();
 };
 
+
+ContentDelegate.prototype.onDownloadSubmit = async function (event) {
+  // Make the Back button redisplay the previous page.
+  window.onpopstate = function (event) {
+    if (event.state.content) {
+      document.documentElement.innerHTML = event.state.content;
+    }
+  };
+  history.replaceState({ content: document.documentElement.innerHTML }, '');
+  // tell the user to wait
+  $('body').css('cursor', 'wait');
+
+  let previousPageHtml = copyPDFDocumentPage();
+  let pdfData = PACER.parseDataFromReceipt();
+
+  const browserSpecificFetch =
+    navigator.userAgent.indexOf('Safari') +
+      navigator.userAgent.indexOf('Chrome') <
+    0
+      ? fetch
+      : window.fetch;
+
+  const documentRequest = await browserSpecificFetch(event.data.id);
+  let documentBlob = await documentRequest.blob();
+
+  let requestHandler = handleDocFormResponse.bind(this);
+  requestHandler(
+    documentRequest.headers.get('Content-Type'),
+    documentBlob,
+    null,
+    previousPageHtml,
+    pdfData
+  );
+};
 
 // checks if a specific document within a combined PDF page is available in
 // the Recap archive. The document is identified by its PACER document ID.

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -166,9 +166,10 @@ ContentDelegate.prototype.findAndStorePacerDocIds = async function () {
   }
   // save JSON object in chrome storage under the tabId
   // append caseId if a docketQueryUrl
-  const payload = {
-    docsToCases: docsToCases,
-  };
+  const payload = {};
+  // Only update the `docsToCases` mapping in the storage if it contains data.
+  if (Object.keys(docsToCases).length) payload['docsToCases'] = docsToCases;
+
   if (!!this.pacer_doc_id) {
     payload['docId'] = this.pacer_doc_id;
   }

--- a/src/pdf_upload.js
+++ b/src/pdf_upload.js
@@ -30,6 +30,11 @@ const downloadDataFromIframe = async(match, tabId) => {
       ? fetch
       : window.fetch;
   const blob = await browserSpecificFetch(match[2]).then((res) => res.blob());
+  const fileType = blob.type;
+  // Allow only specific file types (e.g., PDF) to be stored in the tab storage.
+  // This ensures data integrity.
+  const allowedTypes = ['application/pdf'];
+  if (!allowedTypes.includes(fileType)) return;
   const dataUrl = await blobToDataURL(blob);
   // store the blob in chrome storage for the background worker
   await updateTabStorage({ [tabId]: { ['pdf_blob']: dataUrl } });
@@ -211,6 +216,7 @@ const showAndUploadPdf = async function (
   history.replaceState({ content: previousPageHtml }, '');
 
   let blob = await downloadDataFromIframe(match, this.tabId);
+  if (!blob) return document.documentElement.innerHTML = html_elements;
   let blobUrl = URL.createObjectURL(blob);
   let pacer_case_id;
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -333,6 +333,22 @@ async function getPacerCaseIdFromPacerDocId(tabId, pacer_doc_id) {
   return caseId;
 }
 
+// Retrieves the full Pacer document ID from a partial ID.
+//
+// Fetches the stored documents-to-cases mapping from the current tab's storage
+// Filters out the Pacer document IDs using the provided partial ID. Returns
+// the full Pacer document ID if a single match is found; otherwise, returns
+// `undefined`.
+async function getPacerDocIdFromPartialId(tabId, partialId) {
+  const docsToCases = await getDocToCasesFromStorage(tabId);
+  if (!docsToCases) return;
+
+  let docIds = Object.keys(docsToCases);
+  let pacerDocId = docIds.filter((id) => id.includes(partialId));
+  if (pacerDocId.length === 0) return;
+  return PACER.cleanPacerDocId(pacerDocId[0]);
+}
+
 // Retrieves the Pacer document ID using an exclude list.
 //
 // This function fetches the stored documents-to-cases mapping from the current

--- a/src/utils.js
+++ b/src/utils.js
@@ -333,6 +333,18 @@ async function getPacerCaseIdFromPacerDocId(tabId, pacer_doc_id) {
   return caseId;
 }
 
+// Retrieves the attachment number using the pacer_doc_id
+async function getAttachmentNumberFromPacerDocId(tabId, pacer_doc_id) {
+  const tabStorage = await getItemsFromStorage(tabId);
+  const docsToAttachmentNumbers =
+    tabStorage && tabStorage.docsToAttachmentNumbers;
+  if (!docsToAttachmentNumbers) return;
+
+  const attachmentNumber = docsToAttachmentNumbers[pacer_doc_id];
+  if (!attachmentNumber) return;
+  return attachmentNumber;
+}
+
 // Retrieves the full Pacer document ID from a partial ID.
 //
 // Fetches the stored documents-to-cases mapping from the current tab's storage

--- a/src/utils.js
+++ b/src/utils.js
@@ -330,6 +330,27 @@ async function getPacerCaseIdFromPacerDocId(tabId, pacer_doc_id) {
   return caseId;
 }
 
+// Retrieves the Pacer document ID using an exclude list.
+//
+// This function fetches the stored documents-to-cases mapping from the current
+// tab's storage. It then filters out the Pacer document IDs using the array of
+// the attachment IDs to exclude. If there's only one remaining Pacer document
+// ID, it's returned. Otherwise, undefined is returned.
+async function getPacerDocIdFromExcludeList(tabId, excludeList){
+  const tabStorage = await getItemsFromStorage(tabId);
+
+  const docsToCases = tabStorage && tabStorage.docsToCases;
+  if (!docsToCases) return;
+
+  var pacerDocIds = Object.keys(docsToCases);
+  excludeList.forEach(
+    (attachmentId) =>
+      (pacerDocIds = pacerDocIds.filter((key) => !key.includes(attachmentId)))
+  );
+  if (pacerDocIds.length > 1) return;
+  return PACER.cleanPacerDocId(pacerDocIds[0]);
+}
+
 //Creates an extra button for filer accounts
 function createRecapButtonForFilers(description) {
   let button = document.createElement('input');

--- a/src/utils.js
+++ b/src/utils.js
@@ -315,11 +315,14 @@ const combinedPdfWarning = () => {
   return outerDiv;
 };
 
+async function getDocToCasesFromStorage(tabId){
+  const tabStorage = await getItemsFromStorage(tabId);
+  return tabStorage && tabStorage.docsToCases;
+}
+
 //Given a pacer_doc_id, return the pacer_case_id that it is associated with
 async function getPacerCaseIdFromPacerDocId(tabId, pacer_doc_id) {
-  const tabStorage = await getItemsFromStorage(tabId);
-
-  const docsToCases = tabStorage && tabStorage.docsToCases;
+  const docsToCases = await getDocToCasesFromStorage(tabId);
   if (!docsToCases) return;
 
   const caseId = docsToCases[pacer_doc_id];
@@ -337,9 +340,7 @@ async function getPacerCaseIdFromPacerDocId(tabId, pacer_doc_id) {
 // the attachment IDs to exclude. If there's only one remaining Pacer document
 // ID, it's returned. Otherwise, undefined is returned.
 async function getPacerDocIdFromExcludeList(tabId, excludeList){
-  const tabStorage = await getItemsFromStorage(tabId);
-
-  const docsToCases = tabStorage && tabStorage.docsToCases;
+  const docsToCases = await getDocToCasesFromStorage(tabId);
   if (!docsToCases) return;
 
   var pacerDocIds = Object.keys(docsToCases);


### PR DESCRIPTION
Key changes: 

- Refines the `handleCombinedPdfPageView` (appellate) and `handleCombinedPDFView` (district) methods to accurately identify multi-document pages containing only one PDF file. By analyzing the HTML structure, I noticed that receipt tables are enclosed within **center** divs, and the number of these **divs** corresponds to the number of files in the combined PDF.  Both methods now check for the presence of center nodes to determine if a warning should be displayed.

  In appellate pages, an additional filter was implemented to ensure accurate counting, as center divs may also be used to wrap the page's main content.

- In both district and appellate courts, the document ID is often not directly accessible within the HTML structure of the page. While some courts use the document ID as the entry number, this is not a consistent practice across all jurisdictions. To address this challenge, this PR introduces two helper methods that uses the URL of the PACER page and the existing `DocToCases` mapping stored in our local storage:
    
    -  District court URLs frequently contain a query parameter named `exclude_attachments`. This parameter is a comma-separated list of shortened document IDs that **_are not_** included in the combined PDF. By parsing this list and comparing it to the DocToCases mapping, we can identify the missing document ID.
       
        This PR introduces the `getPacerDocIdFromExcludeList` helper function. It takes a list of excluded document IDs as input and returns the corresponding document ID based on the DocToCases mapping.
    
    - Appellate court URLs often include a query parameter named `dls`. This parameter is a comma-separated list of shortened document IDs that **_are_** included in the combined PDF. By filtering the DocToCases mapping based on this list, we can determine the document ID.

      The `getPacerDocIdFromPartialId` method implements this filtering process, taking the partial as input and returning the extracted document ID.

- Introduces a new utility function, `parseDataFromReceiptTable`, to extract data from receipt tables in appellate courts. While parsing the title alone is often enough for single-document pages, it lacks the necessary information to identify the document in multi-document pages. To address this limitation, this function extracts data directly from the receipt table, providing a more reliable and comprehensive approach.

- Integrate all helper functions into the `handleCombinedPdfPageView` (appellate) and `handleCombinedPDFView` (district) methods. This will enable us to insert banners for available documents and upload the PDFs to the recap archive.

Here are GIFs showing how our extension works in appellate and district courts: 

- District Court: 

![Screen Recording 2024-10-01 at 4 48 23 PM](https://github.com/user-attachments/assets/67d4efd3-0a69-4d66-9c7f-ccaf47b70b31)


- Appellate Court: 

![Screen Recording 2024-10-01 at 3 52 34 PM](https://github.com/user-attachments/assets/ab938c17-6bbd-40a4-b679-922639486be0)


Fixes https://github.com/freelawproject/recap/issues/349