### PR TITLE
fix(notifier): call sendResponse when notifications are disabled

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,7 @@ Fixes:
  - Refines the generateFileName method to accurately compute zip file names ([366](https://github.com/freelawproject/recap/issues/366), [399](https://github.com/freelawproject/recap-chrome/pull/399)).
  - Improves the reliability of PACER case ID retrieval on attachment pages ([369](https://github.com/freelawproject/recap/issues/369), [400](https://github.com/freelawproject/recap-chrome/pull/400)).
  - Fix setDefaultOptions in updateToolbarButton([403](https://github.com/freelawproject/recap-chrome/pull/403))
+ - Ensure we call sendResponse even when notifications are disabled([405](https://github.com/freelawproject/recap-chrome/pull/405))
 
 
 For developers:

--- a/src/utils/background_notifier.js
+++ b/src/utils/background_notifier.js
@@ -64,8 +64,8 @@ export const handleBackgroundNotification = (req, sender, sendResponse) => {
       break;
     case 'showUpload':
       chrome.storage.local.get('options', (items) => {
-        if (!items || !items.options.show_notifications) return;
-        showNotification(title, message);
+        if (items && items.options.show_notifications)
+          showNotification(title, message);
         sendResponse({ status: 'success ' });
       });
       break;


### PR DESCRIPTION
The callers expect a response even if we don't actually show a notification.