### PR TITLE
fix(appellate): Avoids sending attachment number 0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,6 +18,7 @@ Fixes:
  - Ensure we call sendResponse even when notifications are disabled([405](https://github.com/freelawproject/recap-chrome/pull/405))
  - Use chrome.scripting.ExecutionWorld.MAIN for firefox compatibility ([404](https://github.com/freelawproject/recap-chrome/pull/404))
  - Improves getAttachmentNumberFromAnchor to accurately extract attachment numbers from tables with 5+ columns([406](https://github.com/freelawproject/recap-chrome/pull/406))
+ - Refines attachment handling in appellate uploads to only send attachment_number when necessary([382](https://github.com/freelawproject/recap/issues/382),[406](https://github.com/freelawproject/recap-chrome/pull/407))
 
 
 For developers:

--- a/spec/AppellateSpec.js
+++ b/spec/AppellateSpec.js
@@ -77,7 +77,7 @@ describe('The Appellate module', function () {
       );
       expect(titleData.docket_number).toBe('22-11187');
       expect(titleData.doc_number).toBe('49');
-      expect(titleData.att_number).toBe(0);
+      expect(titleData.att_number).toBeNull();
     });
 
     it('parses title with attachment number from download page', function () {
@@ -302,7 +302,7 @@ describe('The Appellate module', function () {
             expect(item.dataset.pacerDlsId).toBe(documentLinks[i]['dlsId']);
             expect(item.dataset.pacerCaseId).toBe('290338');
             expect(item.dataset.pacerTabId).toBe('3');
-            expect(item.dataset.attachmentNumber).toBe('0');
+            expect(item.dataset.attachmentNumber).toBeUndefined();
           }
         });
       });

--- a/spec/PacerSpec.js
+++ b/spec/PacerSpec.js
@@ -780,7 +780,7 @@ describe('The PACER module', function () {
   });
 
   describe('getAttachmentNumberFromAnchor', function () {
-    it('returns 0 if the table has less than four columns', function () {
+    it('returns null if the table has less than four columns', function () {
       let tr = document.createElement('tr');
       let anchor_td = document.createElement('td');
       let anchor = document.createElement('a');
@@ -788,7 +788,7 @@ describe('The PACER module', function () {
       tr.appendChild(document.createElement('td'));
       tr.appendChild(anchor_td);
       tr.appendChild(document.createElement('td'));
-      expect(PACER.getAttachmentNumberFromAnchor(anchor)).toBe(0);
+      expect(PACER.getAttachmentNumberFromAnchor(anchor)).toBeNull();
     });
 
     it('returns the attachment number if the table uses checkboxes', function () {

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -489,7 +489,7 @@ AppellateDelegate.prototype.handleAcmsDownloadPage = async function () {
       att_number:
         downloadData.docketEntry.documentCount > 1
           ? dataFromTitle.att_number
-          : 0,
+          : null,
     };
 
     // Remove element from the page to show loading message
@@ -1114,10 +1114,7 @@ AppellateDelegate.prototype.onDocumentViewSubmit = async function (event) {
   let title = document.querySelectorAll('strong')[1].innerHTML;
   let dataFromTitle = APPELLATE.parseReceiptPageTitle(title);
 
-  if (
-    dataFromTitle.att_number == 0 &&
-    this.queryParameters.get('recapAttNum')
-  ) {
+  if (!dataFromTitle.att_number && this.queryParameters.get('recapAttNum')) {
     dataFromTitle.att_number = this.queryParameters.get('recapAttNum');
   }
 

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -261,9 +261,7 @@ let APPELLATE = {
 
       // if an attachment number is found, it adds it to the link href
       let attNumber = PACER.getAttachmentNumberFromAnchor(a);
-      if (attNumber != 0) {
-        url.searchParams.set('recapAttNum', attNumber);
-      }
+      if (attNumber) url.searchParams.set('recapAttNum', attNumber);
 
       a.setAttribute('href', url.toString());
 
@@ -290,7 +288,7 @@ let APPELLATE = {
       clonedNode.dataset.pacerCaseId = pacerCaseId;
       clonedNode.dataset.pacerTabId = tabId;
       clonedNode.dataset.documentNumber = docNum ? docNum : docId;
-      clonedNode.dataset.attachmentNumber = attNumber;
+      if (attNumber) clonedNode.dataset.attachmentNumber = attNumber;
 
       links.push(docId);
     });
@@ -367,7 +365,7 @@ let APPELLATE = {
       [, r.docket_number, r.doc_number, r.att_number] = dataFromAttachment;
     } else {
       [, r.docket_number, r.doc_number] = dataFromSingleDoc;
-      r.att_number = 0;
+      r.att_number = null;
     }
     return r;
   },

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -729,7 +729,7 @@ let PACER = {
     let row = anchor.parentNode.parentNode;
     if (row.childElementCount <= 3) {
       // Attachment menu pages should have more than 3 element per row.
-      return 0;
+      return null;
     }
 
     //  If the attachment page uses checkboxes, each row should have five or six child nodes and the attachment
@@ -738,7 +738,7 @@ let PACER = {
 
     let rowNumber = [5,6].includes(row.childElementCount) ? row.childNodes[1].innerHTML : row.childNodes[0].innerHTML;
     let cleanNumber = this.cleanDocLinkNumber(rowNumber);
-    return cleanNumber ? cleanNumber : 0;
+    return cleanNumber ? cleanNumber : null;
   },
 
   handleDocketAvailabilityMessages: (resultCount) =>{


### PR DESCRIPTION
While assisting with the debugging of https://github.com/freelawproject/courtlistener/issues/3982, I noticed that a significant number of extension uploads originated from appellate courts. Upon investigating the underlying appellate helper functions, I discovered that some were using 0 as a default value, which leads to unexpected behavior.

This PR addresses this issue by updating the helper functions to use `null` as the default value instead of `0`.


Fixes https://github.com/freelawproject/recap/issues/382