### PR TITLE
fix(utils): Improve Banner Insertion Reliability for regular users

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,6 +6,7 @@ The following changes are not yet released, but are code complete:
 
 Features:
  - Refines logic to accurately identify multi-document pages containing a single file ([349](https://github.com/freelawproject/recap/issues/349), [402](https://github.com/freelawproject/recap-chrome/pull/402)) 
+ - Improve Banner Insertion Reliability ([411](https://github.com/freelawproject/recap-chrome/pull/411))
 
 Changes:
  - None yet

--- a/src/utils.js
+++ b/src/utils.js
@@ -459,7 +459,7 @@ async function checkSingleDocInCombinedPDFPage(
   );
   if (!result.length) return docId;
 
-  let targetDiv = isAppellate ? 'body' : 'form:last';
+  let targetDiv = isAppellate ? 'body' : '#cmecfMainContent';
   insertAvailableDocBanner(result[0].filepath_local, targetDiv);
   return docId;
 }


### PR DESCRIPTION
This PR improves the reliability of banner insertion within the `checkSingleDocInCombinedPDFPage` function. The previous target element for **district courts**, now has the hidden attribute, which could interfere with banner display. This change addresses potential inconsistencies by switching the target element to the main div.