### PR TITLE
feat(appellate): Adds guarding logic for missing pacer_doc_id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,7 +5,7 @@
 The following changes are not yet released, but are code complete:
 
 Features:
- - None yet
+ - More robust guarding logic for missing `pacer_doc_id` in appellate courts ([388](https://github.com/freelawproject/recap/issues/388), [412](https://github.com/freelawproject/recap-chrome/pull/412))
 
 Changes:
  - None yet

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -29,7 +29,8 @@ module.exports = function(config) {
       'src/utils/fetch.js',
       'src/utils/notifier.js',
       'src/pacer.js',
-      'src/toolbar_button.js',
+      { pattern: 'src/utils/url_and_cookie_helpers.js', type: 'module' },
+      { pattern: 'src/utils/toolbar_button.js', type: 'module' },
       'src/utils.js',
       'src/action_button.js',
       'src/pdf_upload.js',
@@ -73,7 +74,7 @@ module.exports = function(config) {
 
     // start these browsers
     // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-    browsers: ['ChromeHeadless'],
+    browsers: ['CustomChromeHeadless'],
 
     // set these options to view logs in development
     // see https://github.com/karma-runner/karma/issues/2582#issuecomment-413660796

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -1084,6 +1084,16 @@ AppellateDelegate.prototype.handleCombinedPdfPageView = async function () {
     return;
   }
 
+  this.docId = await checkSingleDocInCombinedPDFPage(
+    this.tabId,
+    this.court,
+    this.docId,
+    true
+  );
+  // If no pacer_doc_id is available, exit this block to prevent unnecessary
+  // page modifications intended for PDF retrieval.
+  if (!this.docId) return;
+
   await this.overrideDefaultForm();
 
   // When we receive the message from the above submit method, submit the form
@@ -1092,13 +1102,6 @@ AppellateDelegate.prototype.handleCombinedPdfPageView = async function () {
     'message',
     this.onDocumentViewSubmit.bind(this),
     false
-  );
-
-  this.docId = await checkSingleDocInCombinedPDFPage(
-    this.tabId,
-    this.court,
-    this.docId,
-    true
   );
 };
 

--- a/src/appellate/appellate.js
+++ b/src/appellate/appellate.js
@@ -1113,6 +1113,14 @@ AppellateDelegate.prototype.handleSingleDocumentPageView = async function () {
     this.docId
   );
 
+  // Ensure a valid pacer_doc_id before proceeding.
+  let input = document.querySelector('input[name=dls_id]');
+  this.docId = this.docId || (input && input.value);
+
+  // If no pacer_doc_id is available, exit this block to prevent unnecessary
+  // page modifications intended for PDF retrieval.
+  if (!this.docId) return;
+
   let title = document.querySelectorAll('strong')[1].innerHTML;
   let dataFromTitle = APPELLATE.parseReceiptPageTitle(title);
   this.docketNumber = dataFromTitle.docket_number;

--- a/src/appellate/utils.js
+++ b/src/appellate/utils.js
@@ -252,7 +252,8 @@ let APPELLATE = {
       a.setAttribute('target', '_self');
 
       let url = new URL(a.href);
-      url.searchParams.set('caseId', pacerCaseId);
+      // if a case id is found, it adds it to the link href
+      if (pacerCaseId) url.searchParams.set('caseId', pacerCaseId);
 
       if (docNum) {
         url.searchParams.set('recapDocNum', docNum);


### PR DESCRIPTION
This PR adds a check to ensure that the `pacer_doc_id` is available before attempting to retrieve the PDF. If the `pacer_doc_id` is missing, the code will exit early to prevent unintended modifications to the page and incorrect `GET` requests.
![Screen Recording 2025-01-21 at 8 59 35 PM](https://github.com/user-attachments/assets/4aa3dff3-4f02-4f59-81ff-c6dccdd25653)

This PR also updates the `karma.config.js` file to fix some failing tests 

Fixes https://github.com/freelawproject/recap/issues/388