### PR TITLE
feat(district): Clears docketNumber from localStorage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,7 @@ Changes:
  - None yet
 
 Fixes:
- - None yet
+ - Improved handling of localStorage for district courts to avoid using staled docket number values ([392](https://github.com/freelawproject/recap/issues/392), [413](https://github.com/freelawproject/recap-chrome/pull/413))
   
 For developers:
  - Nothing yet

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -175,6 +175,7 @@ ContentDelegate.prototype.findAndStorePacerDocIds = async function () {
   }
   if (PACER.isDocketQueryUrl(this.url) && page_pacer_case_id) {
     payload['caseId'] = page_pacer_case_id;
+    payload['docketNumber'] = '';
   }
 
   updateTabStorage({

--- a/src/utils.js
+++ b/src/utils.js
@@ -72,6 +72,7 @@ const saveCaseIdinTabStorage = async (object, case_id) => {
   const { tabId } = object;
   const payload = {
     caseId: case_id,
+    docketNumber: '',
   };
   await updateTabStorage({
     [tabId]: payload,


### PR DESCRIPTION
This PR fixes  https://github.com/freelawproject/recap/issues/392: `docketNumber` values causing errors after viewing district court reports. Unlike appellate court reports, district court reports lack a consistent source for docket numbers, making extraction unreliable. Therefore, this commit clears the `docketNumber` from **localStorage** when a district court report is loaded, ensuring clean state and preventing unintended use of outdated data.

