### PR TITLE
feat(options): Removes banner about manifest v3

### DIFF
--- a/.github/workflows/check_changelog.yml
+++ b/.github/workflows/check_changelog.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   Check-Changelog:
     name: Check Changelog Action
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: tarides/changelog-check-action@v2
         with:

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,7 +8,7 @@ Features:
  - None yet
 
 Changes:
- - None yet
+ - Cleaned up the UI by removing the banner about manifest update ([395](https://github.com/freelawproject/recap/issues/395), [415](https://github.com/freelawproject/recap-chrome/pull/415))
 
 Fixes:
  - None yet

--- a/src/options.html
+++ b/src/options.html
@@ -9,11 +9,11 @@
 </head>
 
 <body id="options-body">
-  <div id="container" class="grid-with-banner">
+  <div id="container" class="regular-grid">
     <!-- Main Tab Content + Donation plea -->
     <header>
       <div class="d-flex flex-column">
-        <div id="header-banner" class="info-banner d-flex flex-column">
+        <div id="header-banner" hidden class="info-banner d-flex flex-column">
           <div id="message-section" class="d-flex">
             <div class="flex align-items-center banner-icon-container">
               <div id="banner-icon">

--- a/src/utils/toolbar_button.js
+++ b/src/utils/toolbar_button.js
@@ -116,6 +116,7 @@ export function setDefaultOptions(details) {
       recap_enabled: true,
       recap_link_popups: true,
       show_notifications: true,
+      dismiss_news_badge: true,
 
       // Radio button
       ia_style_filenames: false,


### PR DESCRIPTION
Key changes:

- The banner in `options.html` is now hidden, and the header height has been adjusted. This ensures proper alignment of buttons and menu content, creating a clean layout.

- The default settings have been updated to hide the news badge on fresh installations.

fixes https://github.com/freelawproject/recap/issues/395