### PR TITLE
fix(options): Removes conflicting display class to consistently hide banner

### DIFF
--- a/src/options.html
+++ b/src/options.html
@@ -13,7 +13,7 @@
     <!-- Main Tab Content + Donation plea -->
     <header>
       <div class="d-flex flex-column">
-        <div id="header-banner" hidden class="info-banner d-flex flex-column">
+        <div id="header-banner" hidden class="info-banner">
           <div id="message-section" class="d-flex">
             <div class="flex align-items-center banner-icon-container">
               <div id="banner-icon">


### PR DESCRIPTION
PR #415 was supposed to hide the banner within `options.html`. However, while running the QA steps, I noticed the banner was still visible. Upon debugging, I discovered that the `d-flex` class was setting the display property, effectively overriding the `hidden` attribute.

It's possible a cached variable from a previous version of the extension was hiding the banner when I created PR #415, and this was cleared with the update. This PR also addresses and removes other classes that affect the `display` property.