### PR TITLE
fix(district): stop attributing docket uploads to a stale cached case id

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,7 +11,12 @@ Changes:
  - None yet
 
 Fixes:
- - None yet
+ - Stop attributing district docket report uploads to the per-tab cached
+   case id when the page context yields none: derive the id from the
+   sheet's own goDLS document links first. The cached id can belong to a
+   different case viewed earlier in the same tab, which uploaded one
+   case's entire docket sheet under another case's `pacer_case_id` and
+   merged it into the wrong archive docket.
 
 For developers:
  - Nothing yet

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -508,6 +508,27 @@ describe('The ContentDelegate class', function () {
           await cd.handleDocketDisplayPage();
           expect(dispatchBackgroundFetch).not.toHaveBeenCalled();
         });
+
+        it('when a fresh tab has no storage entry at all', async function () {
+          const cd = new ContentDelegate(
+            tabId,
+            docketDisplayUrl,
+            undefined,
+            'canb',
+            undefined,
+            undefined,
+            []
+          );
+          // A tab that never stored anything yields undefined, not {}.
+          window.chrome.storage.local.get = jasmine
+            .createSpy()
+            .and.callFake((_, cb) => {
+              cb({ options: { recap_enabled: true } });
+            });
+          dispatchBackgroundFetch = jasmine.createSpy();
+          await cd.handleDocketDisplayPage();
+          expect(dispatchBackgroundFetch).not.toHaveBeenCalled();
+        });
       });
 
       describe('when the history state is already set', function () {

--- a/spec/ContentDelegateSpec.js
+++ b/spec/ContentDelegateSpec.js
@@ -596,6 +596,16 @@ describe('The ContentDelegate class', function () {
       });
 
       describe('when the docket page is not an interstitial page', function () {
+        const makeLink = (caseId, docId) => {
+          const a = document.createElement('a');
+          a.href = `https://ecf.canb.uscourts.gov/doc1/${docId}`;
+          a.setAttribute(
+            'onclick',
+            `goDLS('/doc1/${docId}','${caseId}','5','','','1','','','');` +
+              'return(false);'
+          );
+          return a;
+        };
         beforeEach(function () {
           clearDocumentBody();
           table = document.createElement('table');
@@ -668,6 +678,133 @@ describe('The ContentDelegate class', function () {
           );
           const button = document.querySelectorAll('#create-alert-button');
           expect(button.length).toBe(1);
+        });
+
+        it('prefers the goDLS case id over a stale tab id', async function () {
+          // The tab's cached caseId ('531591' in the storage mock)
+          // belongs to another case; the page's goDLS links must win.
+          const link = makeLink('177277', '034031424909');
+          const cd = new ContentDelegate(
+            tabId,
+            docketDisplayUrl,
+            docketDisplayPath,
+            'canb',
+            undefined, // no case id derived from url/referrer/inputs
+            undefined,
+            [link]
+          );
+          dispatchBackgroundNotifier = jasmine.createSpy();
+          dispatchBackgroundFetch = jasmine
+            .createSpy()
+            .and.callFake(fakeBackgroundFetch);
+          spyOn(history, 'replaceState');
+          await cd.handleDocketDisplayPage();
+          expect(dispatchBackgroundFetch).toHaveBeenCalledWith(
+            jasmine.objectContaining({
+              action: 'upload',
+              data: jasmine.objectContaining({ pacer_case_id: '177277' }),
+            })
+          );
+          expect(dispatchBackgroundFetch).not.toHaveBeenCalledWith(
+            jasmine.objectContaining({
+              data: jasmine.objectContaining({ pacer_case_id: '531591' }),
+            })
+          );
+          // the stale cached id is corrected for later pages in this tab
+          expect(window.chrome.storage.local.set).toHaveBeenCalledWith(
+            jasmine.objectContaining({
+              1234: jasmine.objectContaining({ caseId: '177277' }),
+            }),
+            jasmine.any(Function)
+          );
+        });
+
+        it('never overrides a context-derived case id', async function () {
+          // On a consolidated MEMBER docket the document links point at
+          // the LEAD case, so an id the page context provided (url,
+          // inputs, referrer) always beats the goDLS majority.
+          const link = makeLink('177277', '034031424909'); // lead case
+          const cd = new ContentDelegate(
+            tabId,
+            docketDisplayUrl,
+            docketDisplayPath,
+            'canb',
+            '531591', // the member case, from the page context
+            undefined,
+            [link]
+          );
+          dispatchBackgroundNotifier = jasmine.createSpy();
+          dispatchBackgroundFetch = jasmine
+            .createSpy()
+            .and.callFake(fakeBackgroundFetch);
+          spyOn(history, 'replaceState');
+          await cd.handleDocketDisplayPage();
+          expect(dispatchBackgroundFetch).toHaveBeenCalledWith(
+            jasmine.objectContaining({
+              action: 'upload',
+              data: jasmine.objectContaining({ pacer_case_id: '531591' }),
+            })
+          );
+        });
+
+        it('uses the majority goDLS id on merged sheets', async function () {
+          // Consolidated/MDL dockets legitimately link member cases'
+          // documents — a stray link must not outvote the sheet.
+          const cd = new ContentDelegate(
+            tabId,
+            docketDisplayUrl,
+            docketDisplayPath,
+            'canb',
+            undefined,
+            undefined,
+            [
+              makeLink('177277', '034031424909'),
+              makeLink('177277', '034031424910'),
+              makeLink('177277', '034031424911'),
+              makeLink('999999', '034031424912'), // stray member-case link
+            ]
+          );
+          dispatchBackgroundNotifier = jasmine.createSpy();
+          dispatchBackgroundFetch = jasmine
+            .createSpy()
+            .and.callFake(fakeBackgroundFetch);
+          spyOn(history, 'replaceState');
+          await cd.handleDocketDisplayPage();
+          expect(dispatchBackgroundFetch).toHaveBeenCalledWith(
+            jasmine.objectContaining({
+              action: 'upload',
+              data: jasmine.objectContaining({ pacer_case_id: '177277' }),
+            })
+          );
+        });
+
+        it('falls back when the goDLS ids are tied', async function () {
+          // Equal votes for two ids: don't guess; use the cached id
+          // ('531591' in the storage mock) as before.
+          const cd = new ContentDelegate(
+            tabId,
+            docketDisplayUrl,
+            docketDisplayPath,
+            'canb',
+            undefined,
+            undefined,
+            [
+              makeLink('177277', '034031424909'),
+              makeLink('888888', '034031424910'),
+            ]
+          );
+          dispatchBackgroundNotifier = jasmine.createSpy();
+          dispatchBackgroundFetch = jasmine
+            .createSpy()
+            .and.callFake(fakeBackgroundFetch);
+          spyOn(history, 'replaceState');
+          await cd.handleDocketDisplayPage();
+          expect(dispatchBackgroundFetch).toHaveBeenCalledWith(
+            jasmine.objectContaining({
+              action: 'upload',
+              data: jasmine.objectContaining({ pacer_case_id: '531591' }),
+            })
+          );
         });
 
         it('calls uploadDocket and responds to a negative result', async function () {

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -286,8 +286,8 @@ ContentDelegate.prototype.handleDocketDisplayPage = async function () {
         );
       }
       this.pacer_case_id = pageCaseId;
-      // Correct the cached id so caseless pages downstream (e.g.
-      // attachment menus) inherit the right one.
+      // Seed the tab's cached case ID so a later docket-report load in this
+      // same tab starts with the correct case ID instead of a stale one.
       await saveCaseIdinTabStorage({ tabId: this.tabId }, pageCaseId);
     } else {
       this.pacer_case_id = tabStorage.caseId;

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -269,12 +269,30 @@ ContentDelegate.prototype.handleDocketDisplayPage = async function () {
   // check if appellate
   // let isAppellate = PACER.isAppellateCourt(this.court);
 
-  // if the content_delegate didn't pull the case Id on initialization,
-  // check the page for a lead case dktrpt url.
-  const tabStorage = await getItemsFromStorage(this.tabId);
-  this.pacer_case_id = this.pacer_case_id
-    ? this.pacer_case_id
-    : tabStorage.caseId;
+  // If initialization yielded no case id, derive it from the page itself:
+  // the sheet's goDLS document links carry it. The per-tab cached id is
+  // the LAST resort — it can belong to a different case viewed earlier in
+  // this tab. An id the page context already provided is never overridden:
+  // consolidated member dockets legitimately link the lead case's
+  // documents, so the goDLS majority only speaks when nothing else does.
+  if (!this.pacer_case_id) {
+    const pageCaseId = PACER.getCaseIdFromDocketDisplayLinks(this.links);
+    const tabStorage = await getItemsFromStorage(this.tabId);
+    if (pageCaseId) {
+      if (tabStorage.caseId && tabStorage.caseId !== pageCaseId) {
+        console.warn(
+          `RECAP: Ignoring cached case id ${tabStorage.caseId}: the ` +
+            `docket's own links say it belongs to case ${pageCaseId}.`
+        );
+      }
+      this.pacer_case_id = pageCaseId;
+      // Correct the cached id so caseless pages downstream (e.g.
+      // attachment menus) inherit the right one.
+      await saveCaseIdinTabStorage({ tabId: this.tabId }, pageCaseId);
+    } else {
+      this.pacer_case_id = tabStorage.caseId;
+    }
+  }
 
   // If we don't have this.pacer_case_id at this point, punt.
   if (!this.pacer_case_id) return;

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -274,7 +274,7 @@ ContentDelegate.prototype.handleDocketDisplayPage = async function () {
   // the LAST resort — it can belong to a different case viewed earlier in
   // this tab. An id the page context already provided is never overridden:
   // consolidated member dockets legitimately link the lead case's
-  // documents, so the goDLS majority only speaks when nothing else does.
+  // documents, so the goDLS plurality only speaks when nothing else does.
   if (!this.pacer_case_id) {
     const pageCaseId = PACER.getCaseIdFromDocketDisplayLinks(this.links);
     const tabStorage = await getItemsFromStorage(this.tabId);

--- a/src/content_delegate.js
+++ b/src/content_delegate.js
@@ -277,7 +277,7 @@ ContentDelegate.prototype.handleDocketDisplayPage = async function () {
   // documents, so the goDLS plurality only speaks when nothing else does.
   if (!this.pacer_case_id) {
     const pageCaseId = PACER.getCaseIdFromDocketDisplayLinks(this.links);
-    const tabStorage = await getItemsFromStorage(this.tabId);
+    const tabStorage = (await getItemsFromStorage(this.tabId)) || {};
     if (pageCaseId) {
       if (tabStorage.caseId && tabStorage.caseId !== pageCaseId) {
         console.warn(

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -462,11 +462,11 @@ let PACER = {
     }
   },
 
-  // Returns the case id a docket report page asserts about itself: the
-  // strict majority of the de_caseid values in its document links' goDLS()
-  // handlers. Majority, because consolidated/MDL sheets legitimately link
-  // member cases' documents. Returns undefined when there is no goDLS
-  // evidence or the top ids are tied.
+  // Returns the most common (plurality) `de_caseid` across the page's
+  // document links' `goDLS()` handlers. Plurality is intentional because
+  // consolidated/MDL docket sheets can legitimately link documents from
+  // multiple member cases. Returns `undefined` when there is no `goDLS`
+  // evidence or when the most common case IDs are tied.
   getCaseIdFromDocketDisplayLinks: function (links) {
     // Count how many document links point to each case ID. The case ID
     // appearing most often is likely the case represented by the docket page.

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -468,27 +468,36 @@ let PACER = {
   // member cases' documents. Returns undefined when there is no goDLS
   // evidence or the top ids are tied.
   getCaseIdFromDocketDisplayLinks: function (links) {
-    let tally = {};
-    for (let i = 0; i < links.length; i++) {
-      if (!PACER.isDoc1Url(links[i].href)) {
-        continue;
-      }
-      let goDLS = PACER.parseGoDLSFunction(links[i].getAttribute('onclick'));
+    // Count how many document links point to each case ID. The case ID
+    // appearing most often is likely the case represented by the docket page.
+    const caseIdCounts = {};
+    for (const link of Array.from(links)) {
+      if (!PACER.isDoc1Url(link.href)) continue;
+
+      const goDLS = PACER.parseGoDLSFunction(link.getAttribute('onclick'));
       if (goDLS && goDLS.de_caseid && goDLS.de_caseid !== '0') {
-        tally[goDLS.de_caseid] = (tally[goDLS.de_caseid] || 0) + 1;
+        caseIdCounts[goDLS.de_caseid] =
+          (caseIdCounts[goDLS.de_caseid] ?? 0) + 1;
       }
     }
-    let best;
-    let tied = false;
-    for (let caseId of Object.keys(tally)) {
-      if (best === undefined || tally[caseId] > tally[best]) {
-        best = caseId;
-        tied = false;
-      } else if (tally[caseId] === tally[best]) {
-        tied = true;
-      }
-    }
-    return tied ? undefined : best;
+
+    // Convert the counts object into an array of [caseId, count] pairs
+    // and sort descending so the most frequently linked case is first.
+    const sortedCaseIds = Object.entries(caseIdCounts).sort(
+      (a, b) => b[1] - a[1]
+    );
+
+    // No valid case IDs were found.
+    if (sortedCaseIds.length === 0) return undefined;
+
+    const [mostLinkedCaseId, mostLinkedCount] = sortedCaseIds[0];
+    const [, secondMostLinkedCount] = sortedCaseIds[1] ?? [];
+
+    // If multiple case IDs have the same highest count, we cannot determine
+    // which case is the correct one, so avoid returning an arbitrary result.
+    const hasTieForFirst = mostLinkedCount === secondMostLinkedCount;
+
+    return hasTieForFirst ? undefined : mostLinkedCaseId;
   },
 
   // Given a URL that satisfies isDocketQueryUrl, gets its case number.

--- a/src/pacer.js
+++ b/src/pacer.js
@@ -462,6 +462,35 @@ let PACER = {
     }
   },
 
+  // Returns the case id a docket report page asserts about itself: the
+  // strict majority of the de_caseid values in its document links' goDLS()
+  // handlers. Majority, because consolidated/MDL sheets legitimately link
+  // member cases' documents. Returns undefined when there is no goDLS
+  // evidence or the top ids are tied.
+  getCaseIdFromDocketDisplayLinks: function (links) {
+    let tally = {};
+    for (let i = 0; i < links.length; i++) {
+      if (!PACER.isDoc1Url(links[i].href)) {
+        continue;
+      }
+      let goDLS = PACER.parseGoDLSFunction(links[i].getAttribute('onclick'));
+      if (goDLS && goDLS.de_caseid && goDLS.de_caseid !== '0') {
+        tally[goDLS.de_caseid] = (tally[goDLS.de_caseid] || 0) + 1;
+      }
+    }
+    let best;
+    let tied = false;
+    for (let caseId of Object.keys(tally)) {
+      if (best === undefined || tally[caseId] > tally[best]) {
+        best = caseId;
+        tied = false;
+      } else if (tally[caseId] === tally[best]) {
+        tied = true;
+      }
+    }
+    return tied ? undefined : best;
+  },
+
   // Given a URL that satisfies isDocketQueryUrl, gets its case number.
   getCaseNumberFromUrls: function (urls) {
     // Iterate over an array of URLs and get the case number from the


### PR DESCRIPTION
## What this fixes

When a district docket report page yields no case id from its own context (URL, inputs, referrer), `handleDocketDisplayPage` falls back to the **per-tab cached case id** and uploads the entire page HTML under it. That cached value can belong to a **different case viewed earlier in the same tab** — nothing invalidates it on navigation — so one case's full docket sheet gets uploaded under another case's `pacer_case_id`, and the archive faithfully merges one case's entire history (entries *and* parties) into the other's docket.

## Real-world occurrence

This happened to a pro se litigant's case in D. Nev.: the complete docket of *Empire Trust v. Cellura* (nvd `3:25-cv-00553`, pacer_case_id `177277`) was uploaded under *Mitchell v. Tate*'s id (nvd `2:26-cv-00720`, pacer_case_id `180126`). CourtListener docket `72456248` now contains ~165 entries byte-identical (same entry numbers, dates, text, and `pacer_doc_id`s) to entries on docket `71566874`, including the foreign case's SDNY pre-transfer history and two of its parties. Both CL docket records carry correct, distinct `pacer_case_id`s, so the wrong id had to be attached client-side at upload time. A data-repair request for that docket was sent separately via the CourtListener contact form.

## The fix

Before reaching for the cached id, derive the case id from the page itself: a district docket sheet carries its own case id in every document link's `goDLS()` onclick handler. New helper `PACER.getCaseIdFromDocketDisplayLinks()` tallies those ids, and the fallback path in `handleDocketDisplayPage` now prefers that evidence over the tab cache:

- The **plurality** (most common) id wins, so a stray link to another case's document — legitimate on consolidated/MDL sheets (the existing comment in `findAndStorePacerDocIds` notes this corner case) — cannot outvote the sheet itself.
- **A tie counts as no evidence** — the cached-id fallback applies as before rather than guessing.
- **An id the page context already provided is never overridden.** On consolidated *member* dockets the document links legitimately point at the *lead* case, so the goDLS plurality is only trusted when there is no context id at all. This keeps the change strictly scoped to the previously-unprotected fallback path — behavior on every other path is byte-for-byte unchanged.
- When the page id beats a conflicting cached id, a console warning says so, and the cached id is **corrected**, seeding the right id for a later docket-report load in the same tab.
- **Pages with no goDLS evidence behave exactly as before** (some courts don't emit goDLS).

## Tests

Five new specs in `ContentDelegateSpec.js`:

- stale tab-cached id + page links assert another id → upload uses the page's id, nothing is sent under the stale id, and the cached id is corrected in storage;
- consolidated **member** docket shape: context-derived id present + goDLS plurality pointing at the lead case → context id wins (never overridden);
- consolidated plurality: three links to the lead case + one stray member-case link → most common id used;
- tied ids → no guessing, cached-id fallback preserved;
- fresh tab with no storage record at all → no throw, no upload (regression for the missing-record guard caught in review).

Full suite: **188/188 passing** (183 pre-existing + 5 new). `CHANGES.md` updated under Upcoming → Fixes.

## Review round 1 (@ERosendo)

All four suggestions adopted, one commit each: the sort-based rewrite of `getCaseIdFromDocketDisplayLinks`, the plurality (not strict-majority) doc wording, the corrected comment on what the tab-storage write feeds (a later docket-report load — attachment menus resolve via `docsToCases`, verified), and the `|| {}` guard on `getItemsFromStorage` with the regression spec above.
